### PR TITLE
Make all-clients export async to avoid prod crashes

### DIFF
--- a/app/Exports/UsersExport.php
+++ b/app/Exports/UsersExport.php
@@ -3,29 +3,37 @@
 namespace App\Exports;
 
 use App\Models\User;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Maatwebsite\Excel\Concerns\Exportable;
 use Maatwebsite\Excel\Concerns\FromQuery;
+use Maatwebsite\Excel\Concerns\WithChunkReading;
 use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithMapping;
 
-class UsersExport implements FromQuery, WithMapping, WithHeadings
+class UsersExport implements FromQuery, WithMapping, WithHeadings, WithChunkReading, ShouldQueue
 {
+    use Exportable;
+
     public function query()
     {
-        return User::query();
+        // Only clients (users without admin/seller roles), matching the "Clientes" listing.
+        return User::query()
+            ->whereDoesntHave('roles')
+            ->with('zones:id,user_id')
+            ->orderBy('name');
     }
 
     public function map($user): array
     {
         $isActive = $user->status_id == User::ACTIVE;
-        $routes = $user->zones->map(function ($zone) {
-            return $zone->id;
-        });
+        $routes = $user->zones->pluck('id')->implode(', ');
+
         return [
             $user->name,
             $user->document,
             $user->email,
             $user->zone,
-            $user->$routes,
+            $routes,
             $isActive ? 'Activo' : 'Inactivo',
         ];
     }
@@ -40,5 +48,10 @@ class UsersExport implements FromQuery, WithMapping, WithHeadings
             'Ruta',
             'Puede Comprar',
         ];
+    }
+
+    public function chunkSize(): int
+    {
+        return 500;
     }
 }

--- a/app/Http/Controllers/Admin/ReportController.php
+++ b/app/Http/Controllers/Admin/ReportController.php
@@ -26,7 +26,7 @@ class ReportController extends Controller
             ],
             'users_export' => [
                 'name' => 'Exportar Usuarios',
-                'description' => 'Exporta todos los usuarios registrados en formato Excel',
+                'description' => 'Genera en segundo plano la exportación de todos los clientes (Excel). Descárgala desde "Mis Exportaciones" en la sección Clientes cuando esté lista.',
                 'has_filters' => false,
                 'type' => 'direct',
                 'url' => '/userexport',

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\City;
+use App\Models\ExportFile;
 use App\Models\Order;
 use App\Models\State;
 use App\Models\User;
@@ -16,7 +17,6 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Storage;
 use Carbon\Carbon;
 use App\Exports\UsersExport;
-use Maatwebsite\Excel\Facades\Excel;
 
 class UserController extends Controller
 {
@@ -173,9 +173,78 @@ class UserController extends Controller
         return back()->with('success', 'Contraseña actualizada');
     }
 
+    /**
+     * Queue an async export of all clients.
+     *
+     * The full clients list is too large to export synchronously (it times out
+     * and exhausts memory in production), so the file is generated in the
+     * background and made available via "Mis Exportaciones".
+     */
     public function export()
     {
-        return Excel::download(new UsersExport, 'usuarios.xlsx');
+        $timestamp = time();
+        $filename = "clientes_{$timestamp}.xlsx";
+
+        $exportFile = ExportFile::create([
+            'user_id' => auth()->id(),
+            'type' => 'clients',
+            'filename' => $filename,
+            'file_path' => "exports/clients/{$filename}",
+            'status' => ExportFile::STATUS_PENDING,
+            'params' => [
+                'label' => 'Clientes ' . now()->format('d/m/Y H:i'),
+            ],
+        ]);
+
+        try {
+            (new UsersExport())
+                ->queue($exportFile->file_path, 'local')
+                ->chain([
+                    function () use ($exportFile) {
+                        $totalRecords = User::query()->whereDoesntHave('roles')->count();
+                        $exportFile->markAsCompleted($totalRecords);
+                    },
+                ]);
+
+            $exportFile->markAsProcessing();
+
+            return back()->with('success', 'La exportación de clientes se está generando en segundo plano. Aparecerá en "Mis Exportaciones" cuando esté lista.');
+        } catch (\Throwable $e) {
+            $exportFile->markAsFailed($e->getMessage());
+
+            return back()->with('error', 'No se pudo iniciar la exportación: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * List the current user's client exports (JSON, used by the exports modal).
+     */
+    public function getExports()
+    {
+        $exports = ExportFile::forUser(auth()->id())
+            ->where('type', 'clients')
+            ->recent(90)
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(function ($export) {
+                return [
+                    'id' => $export->id,
+                    'filename' => $export->filename,
+                    'status' => $export->status,
+                    'label' => $export->params['label'] ?? $export->filename,
+                    'total_records' => $export->total_records,
+                    'file_size' => $export->file_size,
+                    'created_at' => $export->created_at->format('Y-m-d H:i'),
+                    'completed_at' => $export->completed_at?->format('Y-m-d H:i'),
+                    'download_url' => $export->download_url,
+                    'is_completed' => $export->isCompleted(),
+                    'is_processing' => $export->isProcessing(),
+                    'has_failed' => $export->hasFailed(),
+                    'error_message' => $export->error_message,
+                ];
+            });
+
+        return response()->json($exports);
     }
 
     public function updateZone48h(Request $request, User $user, Zone $zone)

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -6,11 +6,22 @@
 
 <div class="p-4 bg-white block sm:flex items-center justify-between border-b border-gray-200">
     <div class="w-full mb-1">
-    <div class="mb-4 flex justify-between">
+    <div class="mb-4 flex items-center justify-between">
             <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl ">Clientes</h1>
-            <a href="/userexport">
-                @svg('heroicon-o-arrow-down-on-square', 'w-8 h-8 text-blue-500')
-            </a>
+            <div class="flex items-center gap-2">
+                <a href="{{ route('admin.export.users') }}"
+                   class="inline-flex items-center px-3 py-2 text-sm font-medium text-white rounded-lg bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300"
+                   title="Generar exportación de clientes">
+                    @svg('heroicon-o-arrow-down-on-square', 'w-5 h-5 sm:mr-2')
+                    <span class="hidden sm:inline">Exportar clientes</span>
+                </a>
+                <button type="button" onclick="openClientExportsModal()"
+                        class="inline-flex items-center px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:ring-4 focus:ring-gray-100"
+                        title="Ver exportaciones generadas">
+                    @svg('heroicon-o-clock', 'w-5 h-5 sm:mr-2')
+                    <span class="hidden sm:inline">Mis Exportaciones</span>
+                </button>
+            </div>
         </div>
         <div class="items-center justify-between block sm:flex md:divide-x md:divide-gray-100 ">
             <div class="flex items-center mb-4 sm:mb-0">
@@ -192,14 +203,127 @@
 
 {{ $users->withQueryString()->links() }} 
 
+<!-- Client Exports List Modal -->
+<div id="clientExportsModal" class="hidden fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50">
+    <div class="relative top-20 mx-auto p-6 border w-full max-w-2xl shadow-lg rounded-md bg-white">
+        <div class="flex justify-between items-center mb-4">
+            <h3 class="text-lg font-medium text-gray-900">Mis Exportaciones de Clientes</h3>
+            <button onclick="closeClientExportsModal()" class="text-gray-400 hover:text-gray-600">
+                @svg('heroicon-o-x-mark', 'w-6 h-6')
+            </button>
+        </div>
+        <div id="clientExportsList" class="space-y-2 max-h-[60vh] overflow-y-auto">
+            <div class="text-center py-8 text-gray-500">Cargando exportaciones...</div>
+        </div>
+        <div class="mt-6 flex justify-end">
+            <button onclick="closeClientExportsModal()"
+                    class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50">
+                Cerrar
+            </button>
+        </div>
+    </div>
+</div>
 
+@endsection
 
+@section('scripts')
+<script>
+let clientExportsPollInterval = null;
 
+function openClientExportsModal() {
+    document.getElementById('clientExportsModal').classList.remove('hidden');
+    loadClientExportsList();
+}
 
+function closeClientExportsModal() {
+    document.getElementById('clientExportsModal').classList.add('hidden');
+    stopClientExportsPolling();
+}
 
+async function loadClientExportsList() {
+    const container = document.getElementById('clientExportsList');
 
+    try {
+        const response = await fetch('{{ route('admin.exports.clients.list') }}');
+        const exports = await response.json();
 
+        if (!exports.length) {
+            container.innerHTML = `
+                <div class="text-center py-8 text-gray-500">
+                    <p>Aún no tienes exportaciones de clientes.</p>
+                    <p class="text-sm mt-2">Usa el botón "Exportar clientes" para generar una.</p>
+                </div>`;
+            stopClientExportsPolling();
+            return;
+        }
 
+        container.innerHTML = exports.map(createClientExportCard).join('');
 
+        // Keep polling while any export is still processing.
+        if (exports.some(exp => exp.is_processing)) {
+            startClientExportsPolling();
+        } else {
+            stopClientExportsPolling();
+        }
+    } catch (error) {
+        console.error('Error loading client exports:', error);
+        container.innerHTML = '<div class="text-center py-8 text-red-500">Error al cargar las exportaciones</div>';
+    }
+}
 
+function startClientExportsPolling() {
+    if (clientExportsPollInterval) return;
+    clientExportsPollInterval = setInterval(loadClientExportsList, 5000);
+}
+
+function stopClientExportsPolling() {
+    if (clientExportsPollInterval) {
+        clearInterval(clientExportsPollInterval);
+        clientExportsPollInterval = null;
+    }
+}
+
+function createClientExportCard(exp) {
+    let statusBadge = '';
+    let actionButton = '';
+
+    if (exp.status === 'completed') {
+        statusBadge = '<span class="px-2 py-1 text-xs font-semibold text-green-800 bg-green-100 rounded-full">Completado</span>';
+        actionButton = `
+            <a href="${exp.download_url}"
+               class="inline-flex items-center px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded hover:bg-blue-700">
+                Descargar
+            </a>`;
+    } else if (exp.is_processing) {
+        statusBadge = '<span class="px-2 py-1 text-xs font-semibold text-yellow-800 bg-yellow-100 rounded-full">Procesando</span>';
+        actionButton = `<span class="text-sm text-gray-500">Preparando archivo...</span>`;
+    } else if (exp.status === 'failed') {
+        statusBadge = '<span class="px-2 py-1 text-xs font-semibold text-red-800 bg-red-100 rounded-full">Error</span>';
+        actionButton = `<span class="text-sm text-red-600">${exp.error_message || 'Error desconocido'}</span>`;
+    }
+
+    return `
+        <div class="border border-gray-200 rounded-lg p-4 hover:bg-gray-50 transition-colors">
+            <div class="flex justify-between items-start">
+                <div class="flex-1">
+                    <div class="flex items-center gap-2 mb-2">
+                        <h4 class="text-sm font-semibold text-gray-900">${exp.label}</h4>
+                        ${statusBadge}
+                    </div>
+                    <div class="text-xs text-gray-600 space-y-1">
+                        <p>Creado: ${exp.created_at}</p>
+                        ${exp.completed_at ? `<p>Completado: ${exp.completed_at}</p>` : ''}
+                        ${exp.total_records ? `<p>Registros: ${exp.total_records.toLocaleString()}</p>` : ''}
+                        ${exp.file_size && exp.status === 'completed' ? `<p>Tamaño: ${exp.file_size}</p>` : ''}
+                    </div>
+                </div>
+                <div class="ml-4">${actionButton}</div>
+            </div>
+        </div>`;
+}
+
+document.getElementById('clientExportsModal').addEventListener('click', function (e) {
+    if (e.target === this) closeClientExportsModal();
+});
+</script>
 @endsection

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -77,6 +77,7 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::post('/users/{user}/password', [UserController::class, 'password'])->name('users.password');
     Route::patch('/users/{user}/zones/{zone}/48h', [UserController::class, 'updateZone48h'])->name('users.zones.48h.update');
     Route::get('/userexport', [UserController::class, 'export'])->name('admin.export.users');
+    Route::get('/clientexports', [UserController::class, 'getExports'])->name('admin.exports.clients.list');
     Route::get('/sellerexport', [SellerController::class, 'export'])->name('admin.export.sellers');
     Route::get('/productexport', [ProductController::class, 'export'])->name('admin.export.products');
     Route::get('/orderexport', [OrderController::class, 'export'])->name('admin.export.orders');


### PR DESCRIPTION
## Summary
- The "all clients" export (`UserController@export`, route `admin.export.users` / `/userexport`) ran **synchronously** via `Excel::download(new UsersExport, ...)`. In production the full clients dataset caused PHP timeouts and memory exhaustion, crashing the report.
- Converted it to a **queued, chunked** export reusing the existing `ExportFile` async infrastructure (the same pattern as the monthly orders export, processed by Horizon in prod).
- `UsersExport` now implements `ShouldQueue` + `WithChunkReading` (500/chunk), eager-loads zones to avoid N+1, scopes to actual clients (`whereDoesntHave('roles')`, matching the "Clientes" listing), and fixes the broken `Ruta` column (was `$user->$routes`).
- `export()` now creates an `ExportFile` record (`type = 'clients'`), dispatches the job with a `chain()` that records the row count and marks it completed, and redirects back with a toast. Added `getExports()` returning the user's recent client exports as JSON.
- Added route `GET /clientexports` (`admin.exports.clients.list`). Download/status reuse the existing generic `admin.exports.download` / `admin.exports.status` routes.
- Clients list view: replaced the single download icon with an "Exportar clientes" button and a "Mis Exportaciones" modal that lists exports, polls every 5s while any are processing, and shows download links when ready.
- Updated the reports dashboard `users_export` description to reflect the new async behavior (it still works: `generate()` redirects to the same GET route, which now queues and redirects back).

## Notes
- Requires the queue worker (Horizon/redis) to be running in prod for true background processing — same dependency as the existing monthly orders export. `master` already has the `ExportFile` model, the `export_files` migration, and the generic export routes, so no schema changes are needed.

## Test plan
- [ ] On the Clientes page, click "Exportar clientes" → toast confirms it's generating in the background.
- [ ] Open "Mis Exportaciones" → entry shows "Procesando", then "Completado" after the worker runs (auto-polls every 5s).
- [ ] Download the completed file and verify columns: Nombre, Documento, Email, Zona, Ruta, Puede Comprar.
- [ ] Verify it no longer times out / crashes with the full production-sized dataset.
- [ ] Reports dashboard "Exportar Usuarios" still triggers the async export and redirects back with the toast.

Made with [Cursor](https://cursor.com)