### PR TITLE
Link product images to specific variation selections

### DIFF
--- a/app/Http/Controllers/Admin/ProductController.php
+++ b/app/Http/Controllers/Admin/ProductController.php
@@ -16,6 +16,7 @@ use App\Models\Variation;
 use App\Models\VariationItem;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\Rule;
 use Image;
 use Illuminate\Support\Str as Str;
 use Closure;
@@ -444,6 +445,11 @@ class ProductController extends Controller
         $validate = $request->validate([
             'images' => 'required',
             'images.*' => 'image|max:4096',
+            'variation_item_id' => [
+                'nullable',
+                Rule::exists('product_item_variation', 'variation_item_id')
+                    ->where(fn ($query) => $query->where('product_id', $product->id)),
+            ],
         ]);
 
         $uploadedCount = 0;
@@ -454,6 +460,7 @@ class ProductController extends Controller
 
             $image = $product->images()->create([
                 'path' => $path,
+                'variation_item_id' => $validate['variation_item_id'] ?? null,
             ]);
 
             // Set position to max(position)+1 within this product
@@ -490,6 +497,28 @@ class ProductController extends Controller
         }
 
         return response()->json(['success' => true]);
+    }
+
+    public function updateImageVariation(Request $request, Product $product, ProductImage $image)
+    {
+        abort_unless((int) $image->product_id === (int) $product->id, 404);
+
+        $validate = $request->validate([
+            'variation_item_id' => [
+                'nullable',
+                Rule::exists('product_item_variation', 'variation_item_id')
+                    ->where(fn ($query) => $query->where('product_id', $product->id)),
+            ],
+        ]);
+
+        $image->update([
+            'variation_item_id' => $validate['variation_item_id'] ?? null,
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'variation_item_id' => $image->variation_item_id,
+        ]);
     }
 
     public function export()

--- a/app/Models/ProductImage.php
+++ b/app/Models/ProductImage.php
@@ -12,5 +12,11 @@ class ProductImage extends Model
     protected $fillable = [
         'path',
         'position',
+        'variation_item_id',
     ];
+
+    public function variationItem()
+    {
+        return $this->belongsTo(VariationItem::class);
+    }
 }

--- a/database/migrations/2026_06_01_040000_add_variation_item_id_to_product_images_table.php
+++ b/database/migrations/2026_06_01_040000_add_variation_item_id_to_product_images_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('product_images', function (Blueprint $table) {
+            $table->unsignedBigInteger('variation_item_id')
+                ->nullable()
+                ->after('product_id');
+
+            $table->foreign('variation_item_id')
+                ->references('id')
+                ->on('variation_items')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('product_images', function (Blueprint $table) {
+            $table->dropForeign(['variation_item_id']);
+            $table->dropColumn('variation_item_id');
+        });
+    }
+};

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -172,6 +172,9 @@ if (imageReorderEl) {
     const props = {
         images: JSON.parse(imageReorderEl.dataset.images || "[]"),
         reorderUrl: imageReorderEl.dataset.reorderUrl,
+        variationItems: JSON.parse(
+            imageReorderEl.dataset.variationItems || "[]"
+        ),
         csrf: document
             .querySelector('meta[name="csrf-token"]')
             .getAttribute("content"),

--- a/resources/js/components/ProductImageReorder.vue
+++ b/resources/js/components/ProductImageReorder.vue
@@ -33,6 +33,13 @@
             </div>
         </div>
 
+        <p
+            v-if="hasVariationItems"
+            class="text-xs text-gray-500"
+        >
+            Asigna cada imagen a una variación para que se muestre cuando el cliente la seleccione. Las imágenes sin variación se muestran siempre.
+        </p>
+
         <div
             ref="grid"
             class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4"
@@ -41,7 +48,7 @@
             <div
                 v-for="(img, index) in localImages"
                 :key="img.id"
-                class="group relative rounded-lg overflow-hidden bg-white border border-gray-200 shadow-sm hover:shadow-md transition-shadow cursor-move"
+                class="group relative rounded-lg overflow-hidden bg-white border border-gray-200 shadow-sm hover:shadow-md transition-shadow cursor-move flex flex-col"
                 draggable="true"
                 @dragstart="onDragStart(index, $event)"
                 @dragenter.prevent="onDragEnter(index)"
@@ -49,11 +56,11 @@
                 @dragend="onDragEnd"
             >
                 <div
-                    class="absolute top-2 left-2 bg-black/60 text-white text-xs px-2 py-0.5 rounded-full"
+                    class="absolute top-2 left-2 bg-black/60 text-white text-xs px-2 py-0.5 rounded-full z-10"
                 >
                     {{ index + 1 }}
                 </div>
-                <div class="absolute top-2 right-2 flex items-center space-x-1">
+                <div class="absolute top-2 right-2 flex items-center space-x-1 z-10">
                     <button
                         type="button"
                         class="p-1 bg-white/90 rounded hover:bg-white shadow"
@@ -79,6 +86,29 @@
                 >
                     <img :src="img.url" class="w-full h-full object-contain" />
                 </div>
+                <div
+                    v-if="hasVariationItems"
+                    class="p-2 border-t border-gray-100 bg-gray-50"
+                    @mousedown.stop
+                    @click.stop
+                >
+                    <label class="sr-only">Variación para imagen {{ index + 1 }}</label>
+                    <select
+                        class="block w-full text-xs text-gray-900 border border-gray-300 rounded bg-white focus:outline-none focus:border-orange-500 p-1.5"
+                        :value="img.variation_item_id ?? ''"
+                        :disabled="savingVariationId === img.id"
+                        @change="onVariationChange(img, $event)"
+                    >
+                        <option value="">Todas las variaciones</option>
+                        <option
+                            v-for="item in variationItems"
+                            :key="item.id"
+                            :value="item.id"
+                        >
+                            {{ item.name }}
+                        </option>
+                    </select>
+                </div>
             </div>
         </div>
 
@@ -100,15 +130,22 @@ export default {
         images: { type: Array, required: true },
         reorderUrl: { type: String, required: true },
         csrf: { type: String, required: true },
+        variationItems: { type: Array, default: () => [] },
     },
     data() {
         return {
             localImages: this.images.slice(),
             dragFromIndex: null,
             isSaving: false,
-            saveState: null, // null | 'success' | 'error'
+            saveState: null,
+            savingVariationId: null,
             toast: { show: false, message: "" },
         };
+    },
+    computed: {
+        hasVariationItems() {
+            return this.variationItems.length > 0;
+        },
     },
     methods: {
         onDragStart(index, e) {
@@ -152,6 +189,46 @@ export default {
             } finally {
                 this.isSaving = false;
                 setTimeout(() => (this.saveState = null), 1500);
+            }
+        },
+        async onVariationChange(img, event) {
+            const rawValue = event.target.value;
+            const variationItemId = rawValue === "" ? null : Number(rawValue);
+            const previousValue = img.variation_item_id ?? null;
+
+            if (previousValue === variationItemId) {
+                return;
+            }
+
+            img.variation_item_id = variationItemId;
+            this.savingVariationId = img.id;
+
+            try {
+                const res = await fetch(img.update_variation_url, {
+                    method: "PATCH",
+                    headers: {
+                        "Content-Type": "application/json",
+                        "X-CSRF-TOKEN": this.csrf,
+                        Accept: "application/json",
+                    },
+                    body: JSON.stringify({
+                        variation_item_id: variationItemId,
+                    }),
+                });
+
+                if (!res.ok) {
+                    throw new Error("failed");
+                }
+
+                const data = await res.json();
+                img.variation_item_id = data.variation_item_id ?? null;
+                this.showToast("Variación actualizada");
+            } catch (e) {
+                img.variation_item_id = previousValue;
+                event.target.value = previousValue ?? "";
+                this.showToast("No se pudo actualizar la variación");
+            } finally {
+                this.savingVariationId = null;
             }
         },
         async confirmDelete(img, index) {

--- a/resources/views/pages/product.blade.php
+++ b/resources/views/pages/product.blade.php
@@ -194,6 +194,26 @@
     <div class="xl:col-span-6 col-span-12">
         <div class="flex justify-center">
             <div class="w-full max-w-md">
+                @php
+                    $variationImageByItem = $product->images
+                        ->whereNotNull('variation_item_id')
+                        ->groupBy('variation_item_id')
+                        ->map(function ($images) {
+                            $firstImage = $images->sortBy('position')->first();
+                            return $firstImage ? asset('storage/' . $firstImage->path) : null;
+                        });
+                    $productImagesPayload = $product->images
+                        ->sortBy('position')
+                        ->values()
+                        ->map(function ($image) {
+                            return [
+                                'url' => asset('storage/' . $image->path),
+                                'variation_item_id' => $image->variation_item_id,
+                            ];
+                        })
+                        ->values()
+                        ->all();
+                @endphp
                 <!-- Main Image Card -->
                 <div class="w-full mb-4 relative bg-white rounded-2xl border border-gray-200 p-4">
                     @if($product->images->first())
@@ -204,9 +224,9 @@
 
                 <!-- Thumbnails -->
                 <div class="w-full flex justify-center">
-                    <ul class="flex gap-3">
+                    <ul id="product-thumbnails" class="flex gap-3 flex-wrap justify-center">
                         @foreach ($product->images as $index => $image)
-                        <li class="thumbnail-item {{ $index === 0 ? 'border-2 border-orange-500' : 'border-2 border-gray-200' }} rounded-lg p-1 hover:border-orange-500 transition-colors cursor-pointer bg-white">
+                        <li class="thumbnail-item {{ $index === 0 ? 'border-2 border-orange-500' : 'border-2 border-gray-200' }} rounded-lg p-1 hover:border-orange-500 transition-colors cursor-pointer bg-white" data-variation-item-id="{{ $image->variation_item_id ?? '' }}">
                             <a href="#" class="thumbnail-link" data-image="{{asset('storage/'.$image->path)}}">
                                 <img src="{{asset('storage/'.$image->path)}}" alt="{{ $product->name }}" class="w-14 h-14 object-contain">
                             </a>
@@ -316,6 +336,7 @@
                     data-has-discount="{{ $fpVar['has_discount'] ? '1' : '0' }}"
                     data-per-item="{{ $fpVar['perItemPrice'] ?? '' }}"
                     data-orderable-stock="{{ $itemOrderableStock }}"
+                    data-variation-image="{{ $variationImageByItem->get($item->id, '') }}"
                     @selected((int) $item->id === (int) $preferredVariationItemId)
                 >{{ $item->name }}</option>
                 @endforeach
@@ -609,15 +630,85 @@
     }
 
     $(function() {
-        // Thumbnail image click handler with selection indicator
-        $('.thumbnail-link').on('click', function(e) {
-            e.preventDefault();
-            var newImageSrc = $(this).data('image');
+        const productImages = @json($productImagesPayload);
+
+        function imagesForVariation(variationItemId) {
+            const variationId = variationItemId ? Number(variationItemId) : null;
+            const generalImages = productImages.filter(function(image) {
+                return image.variation_item_id === null;
+            });
+            const variationImages = productImages.filter(function(image) {
+                return variationId !== null && Number(image.variation_item_id) === variationId;
+            });
+
+            if (variationId !== null && variationImages.length > 0) {
+                return variationImages.concat(generalImages);
+            }
+
+            if (generalImages.length > 0) {
+                return generalImages;
+            }
+
+            return productImages.slice();
+        }
+
+        function updateMainImage(newImageSrc) {
+            if (!newImageSrc) {
+                return;
+            }
+
             $('#mainProductImage').attr('src', newImageSrc);
-            
-            // Update selection indicator
+
+            var $matchingThumb = $('.thumbnail-link').filter(function() {
+                return $(this).data('image') === newImageSrc;
+            }).first();
+
             $('.thumbnail-item').removeClass('border-orange-500').addClass('border-gray-200');
-            $(this).closest('.thumbnail-item').removeClass('border-gray-200').addClass('border-orange-500');
+            if ($matchingThumb.length) {
+                $matchingThumb.closest('.thumbnail-item')
+                    .removeClass('border-gray-200')
+                    .addClass('border-orange-500');
+            }
+        }
+
+        function renderThumbnails(images) {
+            const $list = $('#product-thumbnails');
+            $list.empty();
+
+            images.forEach(function(image, index) {
+                const borderClass = index === 0 ? 'border-orange-500' : 'border-gray-200';
+                const variationAttr = image.variation_item_id ?? '';
+                const item = $('<li>')
+                    .addClass('thumbnail-item border-2 ' + borderClass + ' rounded-lg p-1 hover:border-orange-500 transition-colors cursor-pointer bg-white')
+                    .attr('data-variation-item-id', variationAttr)
+                    .append(
+                        $('<a>')
+                            .attr('href', '#')
+                            .addClass('thumbnail-link')
+                            .attr('data-image', image.url)
+                            .append(
+                                $('<img>')
+                                    .attr('src', image.url)
+                                    .attr('alt', @json($product->name))
+                                    .addClass('w-14 h-14 object-contain')
+                            )
+                    );
+
+                $list.append(item);
+            });
+
+            if (images.length > 0) {
+                updateMainImage(images[0].url);
+            }
+        }
+
+        function applyVariationImages(variationItemId) {
+            renderThumbnails(imagesForVariation(variationItemId));
+        }
+
+        $('#product-thumbnails').on('click', '.thumbnail-link', function(e) {
+            e.preventDefault();
+            updateMainImage($(this).data('image'));
         });
 
         const step = parseInt('{{$product->step}}');
@@ -685,7 +776,11 @@
                         $low.addClass('hidden');
                     }
                 }
+
+                applyVariationImages($(this).val());
             });
+
+            $sel.trigger('change');
         }
 
     })

--- a/resources/views/products/edit.blade.php
+++ b/resources/views/products/edit.blade.php
@@ -377,17 +377,27 @@
     <div class="col-span-2">
         <div class="bg-white dark:bg-gray-800 relative shadow-md sm:rounded-lg overflow-hidden p-4">
             @php
+                $enabledVariationItems = $product->items->where('pivot.enabled', 1)->values();
                 $imagesPayload = $product->images->map(function ($img) use ($product) {
                     return [
                         'id' => $img->id,
                         'url' => asset('storage/'.$img->path),
                         'delete_url' => route('products.images_delete', [$product, $img]),
+                        'update_variation_url' => route('products.images_variation', [$product, $img]),
+                        'variation_item_id' => $img->variation_item_id,
+                    ];
+                })->values()->all();
+                $variationItemsPayload = $enabledVariationItems->map(function ($item) {
+                    return [
+                        'id' => $item->id,
+                        'name' => $item->name,
                     ];
                 })->values()->all();
             @endphp
             <div
                 id="product-image-reorder"
                 data-images='@json($imagesPayload)'
+                data-variation-items='@json($variationItemsPayload)'
                 data-reorder-url="{{ route('products.images_reorder', $product) }}"
             ></div>
         </div>
@@ -399,6 +409,23 @@
             <div class="p-4 mb-4 bg-white border border-gray-200 rounded-lg shadow-sm 2xl:col-span-2 ">
                 <h3 class="mb-4 text-xl font-semibold ">Imagenes</h3>
                 <div class="col-span-2 space-y-3">
+                    @php
+                        $enabledVariationItems = $product->items->where('pivot.enabled', 1)->values();
+                    @endphp
+                    @if($product->variation && $enabledVariationItems->count())
+                    <div>
+                        <label for="variation_item_id" class="block text-sm font-medium text-gray-700 mb-2">Asociar nuevas imágenes a variación (opcional)</label>
+                        <select id="variation_item_id" name="variation_item_id" class="block w-full text-sm text-gray-900 border border-gray-300 rounded-lg bg-white focus:outline-none focus:border-orange-500 p-2">
+                            <option value="">Sin variación específica</option>
+                            @foreach($enabledVariationItems as $variationItem)
+                                <option value="{{ $variationItem->id }}">
+                                    {{ $variationItem->name }}
+                                </option>
+                            @endforeach
+                        </select>
+                        <p class="mt-1 text-xs text-gray-500">Las imágenes ya cargadas se asignan en la cuadrícula de la izquierda. Aquí puedes elegir la variación al subir imágenes nuevas.</p>
+                    </div>
+                    @endif
                     <div>
                         <label class="block text-sm font-medium text-gray-700 mb-2">Seleccione una o más imágenes</label>
                         <input type="file" name="images[]" multiple accept="image/*" class="block w-full text-sm text-gray-900 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 focus:outline-none focus:border-blue-500 p-2">

--- a/resources/views/products/variations.blade.php
+++ b/resources/views/products/variations.blade.php
@@ -80,7 +80,29 @@
                                     </div>
                                 @endif
                             </td>
-                            
+
+                            <td class="px-4 py-3">
+                                @php
+                                    $variationImages = $product->images
+                                        ->where('variation_item_id', $item->id)
+                                        ->sortBy('position');
+                                    $primaryVariationImage = $variationImages->first();
+                                @endphp
+                                @if($primaryVariationImage)
+                                    <div class="flex items-center gap-2">
+                                        <img
+                                            src="{{ asset('storage/'.$primaryVariationImage->path) }}"
+                                            alt="{{ $item->name }}"
+                                            class="w-12 h-12 object-contain rounded border border-gray-200 bg-white"
+                                        >
+                                        @if($variationImages->count() > 1)
+                                            <span class="text-xs text-gray-500">+{{ $variationImages->count() - 1 }}</span>
+                                        @endif
+                                    </div>
+                                @else
+                                    <span class="text-xs text-gray-400">Sin imagen</span>
+                                @endif
+                            </td>
 
                         
                         </tr>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -67,6 +67,7 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::post('/products/{product}/images', [ProductController::class, 'images'])->name('products.images');
     Route::delete('/products/{product}/images/{image}', [ProductController::class, 'images_delete'])->name('products.images_delete');
     Route::post('/products/{product}/images/reorder', [ProductController::class, 'reorderImages'])->name('products.images_reorder');
+    Route::patch('/products/{product}/images/{image}/variation', [ProductController::class, 'updateImageVariation'])->name('products.images_variation');
 
     Route::delete('/products/{product}/add_combined', [ProductController::class, 'add_combined'])->name('products.add_combined');
     Route::delete('/products/{product}/sync_combined', [ProductController::class, 'sync_combined'])->name('products.sync_combined');

--- a/tests/Feature/ProductImageVariationTest.php
+++ b/tests/Feature/ProductImageVariationTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use App\Models\Product;
+use App\Models\User;
+use App\Models\Variation;
+use App\Models\VariationItem;
+use Database\Factories\BrandFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\patchJson;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $user = User::factory()->create();
+    Role::create(['name' => 'admin', 'guard_name' => 'web']);
+    $user->assignRole('admin');
+    actingAs($user);
+});
+
+function productWithVariations(): array
+{
+    $variation = Variation::create(['name' => 'Color']);
+    $red = VariationItem::create(['name' => 'Rojo', 'variation_id' => $variation->id]);
+    $blue = VariationItem::create(['name' => 'Azul', 'variation_id' => $variation->id]);
+
+    $product = Product::factory()
+        ->for(BrandFactory::new())
+        ->state(['variation_id' => $variation->id])
+        ->create();
+
+    $product->items()->sync([
+        $red->id => ['price' => 1000, 'enabled' => 1, 'sku' => 'RED'],
+        $blue->id => ['price' => 1000, 'enabled' => 1, 'sku' => 'BLUE'],
+    ]);
+
+    $image = $product->images()->create([
+        'path' => 'products/test.jpg',
+        'position' => 1,
+        'variation_item_id' => null,
+    ]);
+
+    return compact('product', 'red', 'blue', 'image');
+}
+
+it('updates image variation assignment for a product image', function () {
+    ['product' => $product, 'red' => $red, 'image' => $image] = productWithVariations();
+
+    patchJson(route('products.images_variation', [$product, $image]), [
+        'variation_item_id' => $red->id,
+    ])
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'variation_item_id' => $red->id,
+        ]);
+
+    expect($image->fresh()->variation_item_id)->toBe($red->id);
+});
+
+it('clears image variation assignment', function () {
+    ['product' => $product, 'red' => $red, 'image' => $image] = productWithVariations();
+    $image->update(['variation_item_id' => $red->id]);
+
+    patchJson(route('products.images_variation', [$product, $image]), [
+        'variation_item_id' => null,
+    ])
+        ->assertOk()
+        ->assertJson([
+            'success' => true,
+            'variation_item_id' => null,
+        ]);
+
+    expect($image->fresh()->variation_item_id)->toBeNull();
+});
+
+it('rejects variation assignment for items not linked to the product', function () {
+    ['product' => $product, 'image' => $image] = productWithVariations();
+
+    $otherVariation = Variation::create(['name' => 'Talla']);
+    $otherItem = VariationItem::create(['name' => 'XL', 'variation_id' => $otherVariation->id]);
+
+    patchJson(route('products.images_variation', [$product, $image]), [
+        'variation_item_id' => $otherItem->id,
+    ])->assertUnprocessable();
+});
+
+it('rejects updating an image that belongs to another product', function () {
+    ['product' => $product, 'red' => $red] = productWithVariations();
+
+    $otherProduct = Product::factory()
+        ->for(BrandFactory::new())
+        ->create();
+
+    $foreignImage = $otherProduct->images()->create([
+        'path' => 'products/other.jpg',
+        'position' => 1,
+    ]);
+
+    patchJson(route('products.images_variation', [$product, $foreignImage]), [
+        'variation_item_id' => $red->id,
+    ])->assertNotFound();
+});


### PR DESCRIPTION
## Summary
- Adds `variation_item_id` on product images so each image can be tied to a variation option.
- Admin product edit: per-image variation dropdown in the image grid, upload-time assignment, and previews in the variations table.
- Storefront PDP: filters thumbnails and updates the main image when the shopper changes variation.

## Test plan
- [ ] Run migration on staging: `php artisan migrate`
- [ ] Rebuild assets: `npm run build`
- [ ] Edit a product with variations; assign images to specific options in the image grid
- [ ] Open the product on the storefront and confirm the gallery changes when switching variations
- [x] `php artisan test tests/Feature/ProductImageVariationTest.php`


Made with [Cursor](https://cursor.com)