### PR TITLE
Add Mi Ruta seller tab and client data updates from stage

### DIFF
--- a/app/Console/Commands/SyncZoneRuterosWeekly.php
+++ b/app/Console/Commands/SyncZoneRuterosWeekly.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\SyncZoneRuteros;
+use App\Models\Setting;
+use App\Models\User;
+use App\Models\Zone;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class SyncZoneRuterosWeekly extends Command
+{
+    protected $signature = 'clients:sync-zone-ruteros';
+
+    protected $description = 'Queue Dynamics (getRuteros) sync per zone to refresh clients zona/ruta/día (weekly job)';
+
+    public function handle(): int
+    {
+        $enabled = Setting::getByKeyWithDefault('weekly_zone_rutero_sync_enabled', '1');
+        if ($enabled !== '1' && $enabled !== 1 && $enabled !== true) {
+            $this->info('Weekly zone rutero sync is disabled (setting weekly_zone_rutero_sync_enabled).');
+
+            return self::SUCCESS;
+        }
+
+        // Possible zones: seller zones plus every zone already present on client zone rows.
+        $zoneCodes = User::query()
+            ->whereRelation('roles', 'name', 'seller')
+            ->whereNotNull('zone')
+            ->where('zone', '!=', '')
+            ->pluck('zone')
+            ->merge(
+                Zone::query()
+                    ->whereNotNull('zone')
+                    ->where('zone', '!=', '')
+                    ->distinct()
+                    ->pluck('zone')
+            )
+            ->map(fn ($zone) => trim((string) $zone))
+            ->filter()
+            ->unique()
+            ->sort()
+            ->values()
+            ->all();
+
+        if ($zoneCodes === []) {
+            $this->warn('No zones found to sync.');
+
+            return self::SUCCESS;
+        }
+
+        $sessionId = 'zones-' . now()->format('Ymd-His') . '-' . Str::random(8);
+
+        $queueConnection = config('queue.default');
+        if ($queueConnection === 'sync') {
+            $queueConnection = 'database';
+        }
+
+        SyncZoneRuteros::dispatch($zoneCodes, $sessionId)
+            ->onConnection($queueConnection)
+            ->onQueue('default');
+
+        $this->info('Dispatched zone rutero sync for ' . count($zoneCodes) . ' zones. Session: ' . $sessionId);
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -67,6 +67,12 @@ class Kernel extends ConsoleKernel
             ->dailyAt('03:20')
             ->withoutOverlapping()
             ->runInBackground();
+
+        // Weekly per-zone rutero sync (getRuteros by zone): refreshes clients zona/ruta/día — guarded by setting
+        $schedule->command('clients:sync-zone-ruteros')
+            ->weeklyOn(0, '04:15')
+            ->withoutOverlapping()
+            ->runInBackground();
     }
 
     /**

--- a/app/Http/Controllers/Admin/ClientDataUpdateRequestController.php
+++ b/app/Http/Controllers/Admin/ClientDataUpdateRequestController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\ClientDataUpdateRequest;
+use Illuminate\Http\Request;
+
+class ClientDataUpdateRequestController extends Controller
+{
+    public function index(Request $request)
+    {
+        $requests = ClientDataUpdateRequest::query()
+            ->with(['client:id,name,document', 'seller:id,name', 'zone:id,address'])
+            ->when($request->filled('q'), function ($query) use ($request) {
+                $term = (string) $request->input('q');
+                $query->where(function ($sub) use ($term) {
+                    $sub->where('document', 'like', "%{$term}%")
+                        ->orWhere('name', 'ilike', "%{$term}%")
+                        ->orWhere('business_name', 'ilike', "%{$term}%");
+                });
+            })
+            ->when($request->filled('date_from'), function ($query) use ($request) {
+                $query->whereDate('created_at', '>=', (string) $request->input('date_from'));
+            })
+            ->when($request->filled('date_to'), function ($query) use ($request) {
+                $query->whereDate('created_at', '<=', (string) $request->input('date_to'));
+            })
+            ->orderByDesc('id')
+            ->paginate()
+            ->withQueryString();
+
+        return view('client-data-update-requests.index', compact('requests'));
+    }
+
+    public function show(ClientDataUpdateRequest $clientDataUpdateRequest)
+    {
+        if (!$clientDataUpdateRequest->read_at) {
+            $clientDataUpdateRequest->forceFill(['read_at' => now()])->save();
+        }
+
+        $clientDataUpdateRequest->load(['client.city', 'seller', 'zone']);
+
+        return view('client-data-update-requests.show', [
+            'updateRequest' => $clientDataUpdateRequest,
+        ]);
+    }
+}

--- a/app/Http/Controllers/ClientDataUpdateController.php
+++ b/app/Http/Controllers/ClientDataUpdateController.php
@@ -1,0 +1,287 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ClientDataUpdateRequest;
+use App\Models\User;
+use App\Models\Zone;
+use App\Repositories\UserRepository;
+use App\Rules\ValidClientEmail;
+use App\Services\MailingService;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use Illuminate\View\View;
+
+class ClientDataUpdateController extends Controller
+{
+    public function edit(Request $request, Zone $zone): View|RedirectResponse
+    {
+        $this->authorizeSellerZoneAccess($zone);
+
+        $zone->load(['user.city']);
+
+        return view('client-data-updates.edit', $this->formViewData($zone->user, $zone, [
+            'returnTab' => (string) $request->query('return_tab', 'mi-ruta'),
+            'returnRoute' => (string) $request->query('ruta', ''),
+        ]));
+    }
+
+    public function store(Request $request, Zone $zone): RedirectResponse
+    {
+        $this->authorizeSellerZoneAccess($zone);
+
+        $zone->load(['user.city']);
+        $client = $zone->user;
+
+        if (!$client) {
+            abort(404);
+        }
+
+        $validated = $this->validateUpdateRequest($request, requireValidEmail: false);
+        $validated = $this->applyRuteroRouteData($client, $zone, $validated);
+
+        $this->createUpdateRequest($zone, $client, $request->user(), $validated);
+
+        $redirectParams = array_filter([
+            'tab' => $validated['return_tab'] ?? 'mi-ruta',
+            'ruta' => $validated['return_route'] ?? null,
+        ]);
+
+        return redirect()
+            ->route('clients.orders.index', $redirectParams)
+            ->with('success', 'La solicitud de actualización de datos fue enviada correctamente.');
+    }
+
+    public function clientEdit(Request $request): View|RedirectResponse
+    {
+        $user = $request->user();
+
+        if (!$user || !$user->requiresClientEmailUpdate()) {
+            return redirect()->route('home');
+        }
+
+        $user->load('city');
+        $zone = $user->zones()->first();
+
+        return view('client-data-updates.edit', $this->formViewData($user, $zone, [
+            'isClientSelfService' => true,
+        ]));
+    }
+
+    public function clientStore(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        if (!$user || !$user->requiresClientEmailUpdate()) {
+            return redirect()->route('home');
+        }
+
+        $zone = $user->zones()->first();
+        if ($zone && $zone->user_id !== $user->id) {
+            abort(404);
+        }
+
+        $validated = $this->validateUpdateRequest($request, requireValidEmail: true);
+        $validated = $this->applyRuteroRouteData($user, $zone, $validated);
+        $this->createUpdateRequest($zone, $user, $user, $validated);
+
+        return redirect()
+            ->route('client-data-updates.client.edit')
+            ->with('success', 'Tu solicitud de actualización fue enviada. Te contactaremos cuando tus datos estén listos.');
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function formViewData(User $client, ?Zone $zone = null, array $extra = []): array
+    {
+        $ruteroRoute = $this->resolveRuteroRoute($client, $zone);
+
+        return array_merge([
+            'zone' => $zone,
+            'client' => $client,
+            'ruteroRoute' => $ruteroRoute,
+            'ruteroUnavailable' => $ruteroRoute === null && $this->documentForRutero($client) !== '',
+            'returnTab' => 'mi-ruta',
+            'returnRoute' => '',
+            'isClientSelfService' => false,
+        ], $extra);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validateUpdateRequest(Request $request, bool $requireValidEmail): array
+    {
+        $emailRules = $requireValidEmail
+            ? ['required', 'email', 'max:255', new ValidClientEmail()]
+            : ['nullable', 'email', 'max:255', new ValidClientEmail()];
+
+        return $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'business_name' => ['nullable', 'string', 'max:255'],
+            'document' => ['required', 'string', 'max:20'],
+            'email' => $emailRules,
+            'phone' => ['nullable', 'string', 'max:30'],
+            'mobile_phone' => ['nullable', 'string', 'max:30'],
+            'whatsapp' => ['nullable', 'string', 'max:30'],
+            'address' => ['required', 'string', 'max:255'],
+            'city_name' => ['nullable', 'string', 'max:255'],
+            'seller_notes' => ['nullable', 'string', 'max:2000'],
+            'return_tab' => ['nullable', 'string', 'max:50'],
+            'return_route' => ['nullable', 'string', 'max:100'],
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $validated
+     */
+    private function createUpdateRequest(
+        ?Zone $zone,
+        User $client,
+        User $submittedBy,
+        array $validated
+    ): ClientDataUpdateRequest {
+        $updateRequest = ClientDataUpdateRequest::create([
+            'user_id' => $client->id,
+            'zone_id' => $zone?->id,
+            'submitted_by' => $submittedBy->id,
+            'document' => preg_replace('/\D+/', '', $validated['document']),
+            'name' => $validated['name'],
+            'business_name' => $validated['business_name'] ?? null,
+            'email' => $validated['email'] ?? null,
+            'phone' => $validated['phone'] ?? null,
+            'mobile_phone' => $validated['mobile_phone'] ?? null,
+            'whatsapp' => $validated['whatsapp'] ?? null,
+            'address' => $validated['address'],
+            'city_name' => $validated['city_name'] ?? null,
+            'zone_code' => $validated['zone_code'] ?? null,
+            'route' => $validated['route'] ?? null,
+            'day' => $validated['day'] ?? null,
+            'seller_notes' => $validated['seller_notes'] ?? null,
+            'previous_data' => [
+                'name' => $client->name,
+                'business_name' => $client->business_name,
+                'document' => $client->document,
+                'email' => $client->clientDisplayEmail(),
+                'phone' => $client->phone,
+                'mobile_phone' => $client->mobile_phone,
+                'whatsapp' => $client->whatsapp,
+                'address' => $zone?->address,
+                'city_name' => $client->city?->name,
+                'zone_code' => $zone?->zone,
+                'route' => $zone?->route,
+                'day' => $zone?->day,
+            ],
+        ]);
+
+        app(MailingService::class)->sendClientDataUpdateNotification($updateRequest);
+
+        return $updateRequest;
+    }
+
+    /**
+     * @return array{zone_code: ?string, route: ?string, day: ?string, address: ?string}|null
+     */
+    private function resolveRuteroRoute(User $client, ?Zone $zone = null): ?array
+    {
+        $document = $this->documentForRutero($client);
+        if ($document === '') {
+            return null;
+        }
+
+        $zoneFilter = $zone?->zone ?: null;
+        $rutero = UserRepository::getCustomRuteroId($document, $zoneFilter);
+        if (!$rutero || empty($rutero['routes'])) {
+            return null;
+        }
+
+        $routes = collect($rutero['routes']);
+
+        if ($zone) {
+            $matched = $routes->first(function (array $route) use ($zone) {
+                if ($zone->zone && trim((string) ($route['zone'] ?? '')) !== trim((string) $zone->zone)) {
+                    return false;
+                }
+
+                if ($zone->route && trim((string) ($route['route'] ?? '')) !== trim((string) $zone->route)) {
+                    return false;
+                }
+
+                $routeCode = trim((string) ($route['code'] ?? ''));
+                if ($zone->code && $routeCode !== '' && $routeCode !== trim((string) $zone->code)) {
+                    return false;
+                }
+
+                return true;
+            });
+
+            if ($matched) {
+                return $this->normalizeRuteroRouteRow($matched);
+            }
+        }
+
+        $first = $routes->first();
+
+        return is_array($first) ? $this->normalizeRuteroRouteRow($first) : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $route
+     * @return array{zone_code: ?string, route: ?string, day: ?string, address: ?string}
+     */
+    private function normalizeRuteroRouteRow(array $route): array
+    {
+        return [
+            'zone_code' => isset($route['zone']) ? trim((string) $route['zone']) : null,
+            'route' => isset($route['route']) ? trim((string) $route['route']) : null,
+            'day' => isset($route['day']) ? trim((string) $route['day']) : null,
+            'address' => isset($route['address']) ? trim((string) $route['address']) : null,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $validated
+     * @return array<string, mixed>
+     */
+    private function applyRuteroRouteData(User $client, ?Zone $zone, array $validated): array
+    {
+        $ruteroRoute = $this->resolveRuteroRoute($client, $zone);
+        if (!$ruteroRoute) {
+            throw ValidationException::withMessages([
+                'document' => 'No pudimos consultar la zona y la ruta en Tronex. Intenta más tarde o contáctanos.',
+            ]);
+        }
+
+        $validated['zone_code'] = $ruteroRoute['zone_code'];
+        $validated['route'] = $ruteroRoute['route'];
+        $validated['day'] = $ruteroRoute['day'];
+
+        return $validated;
+    }
+
+    private function documentForRutero(User $client): string
+    {
+        return preg_replace('/\D+/', '', (string) $client->document);
+    }
+
+    private function authorizeSellerZoneAccess(Zone $zone): void
+    {
+        $seller = auth()->user();
+
+        if (!$seller || !$seller->hasAnyRole(['seller', 'supervisor', 'admin'])) {
+            abort(403);
+        }
+
+        if (!$zone->user_id) {
+            abort(404);
+        }
+
+        $sellerZone = trim((string) $seller->zone);
+        if ($sellerZone !== '' && trim((string) $zone->zone) !== $sellerZone) {
+            abort(403);
+        }
+    }
+}

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -44,6 +44,8 @@ class OrderController extends Controller
                 ->withQueryString()
             : null;
 
+        $myRoute = $isSeller ? $this->buildMyRouteData($user, $request) : null;
+
         $statuses = [
             '' => 'Todos',
             0 => 'Pendiente',
@@ -62,8 +64,65 @@ class OrderController extends Controller
             'isSeller',
             'sellerDashToday',
             'recentFilters',
-            'todayFilters'
+            'todayFilters',
+            'myRoute'
         ));
+    }
+
+    /**
+     * Data for the seller "Mi Ruta" tab: routes available in the seller's zone and,
+     * once a route is selected, the clients whose visit day matches today (Colombia).
+     *
+     * @return array{sellerZone:string,routeOptions:\Illuminate\Support\Collection,selectedRoute:string,clients:\Illuminate\Support\Collection|null,todayLabel:string}
+     */
+    private function buildMyRouteData(User $user, Request $request): array
+    {
+        $sellerZone = trim((string) $user->zone);
+        $today = Carbon::now($this->sellerReportTimezone());
+
+        $routeOptions = $sellerZone === ''
+            ? collect()
+            : Zone::query()
+                ->where('zone', $sellerZone)
+                ->whereNotNull('route')
+                ->where('route', '!=', '')
+                ->distinct()
+                ->orderBy('route')
+                ->pluck('route');
+
+        $selectedRoute = trim((string) $request->input('ruta', ''));
+        if ($selectedRoute === '' || !$routeOptions->contains($selectedRoute)) {
+            $selectedRoute = '';
+        }
+
+        $clients = null;
+        if ($selectedRoute !== '') {
+            $todayDow = $today->dayOfWeek;
+
+            $clients = Zone::query()
+                ->with('user:id,name,document,business_name,phone,mobile_phone,order_sequence')
+                ->where('zone', $sellerZone)
+                ->where('route', $selectedRoute)
+                ->get()
+                ->filter(fn (Zone $zone) => $zone->user !== null
+                    && Zone::carbonDayOfWeekFromDay($zone->day) === $todayDow)
+                ->sortBy(function (Zone $zone) {
+                    // Visit order (aOrden) first when available, then name.
+                    $sequence = (int) ($zone->user->order_sequence ?? 0);
+                    $sequenceKey = $sequence > 0 ? str_pad((string) $sequence, 10, '0', STR_PAD_LEFT) : '9999999999';
+
+                    return $sequenceKey . '|' . mb_strtolower((string) $zone->user->name, 'UTF-8');
+                })
+                ->values();
+        }
+
+        return [
+            'sellerZone' => $sellerZone,
+            'routeOptions' => $routeOptions,
+            'selectedRoute' => $selectedRoute,
+            'clients' => $clients,
+            'todayLabel' => $today->locale('es')->isoFormat('dddd D [de] MMMM'),
+        ];
     }
 
     public function export(Request $request)

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -100,7 +100,10 @@ class OrderController extends Controller
             $todayDow = $today->dayOfWeek;
 
             $clients = Zone::query()
-                ->with('user:id,name,document,business_name,phone,mobile_phone,order_sequence')
+                ->with([
+                    'user:id,name,document,business_name,phone,mobile_phone,whatsapp,email,order_sequence,city_id',
+                    'user.city:id,name',
+                ])
                 ->where('zone', $sellerZone)
                 ->where('route', $selectedRoute)
                 ->get()

--- a/app/Jobs/SyncZoneRuteros.php
+++ b/app/Jobs/SyncZoneRuteros.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Setting;
+use App\Models\Zone;
+use App\Repositories\UserRepository;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Weekly sync: pulls every rutero per zone from Dynamics (getRuteros without
+ * document filter) and refreshes the clients' zona/ruta/día on their zone rows,
+ * matched by CustRuteroID (zones.code).
+ */
+class SyncZoneRuteros implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public $tries = 1;
+
+    public $timeout = 7200; // 2 hours
+
+    /**
+     * @param  array<int, string>  $zoneCodes
+     */
+    public function __construct(
+        protected array $zoneCodes,
+        protected string $sessionId,
+    ) {}
+
+    public function handle(): void
+    {
+        $summary = [
+            'zones_processed' => 0,
+            'zones_failed' => 0,
+            'zones_empty' => 0,
+            'ruteros_seen' => 0,
+            'ruteros_without_code' => 0,
+            'ruteros_unmatched' => 0,
+            'zone_rows_updated' => 0,
+        ];
+
+        Log::info('Zone rutero sync started', [
+            'session_id' => $this->sessionId,
+            'zones' => count($this->zoneCodes),
+        ]);
+
+        foreach ($this->zoneCodes as $zoneCode) {
+            try {
+                $ruteros = UserRepository::getRuterosForZone($zoneCode);
+            } catch (\Throwable $e) {
+                $summary['zones_failed']++;
+                Log::error('Zone rutero sync: fetch failed for zone', [
+                    'session_id' => $this->sessionId,
+                    'zone' => $zoneCode,
+                    'error' => $e->getMessage(),
+                ]);
+                continue;
+            }
+
+            if ($ruteros === null || $ruteros->isEmpty()) {
+                $summary['zones_empty']++;
+                Log::warning('Zone rutero sync: no ruteros returned for zone', [
+                    'session_id' => $this->sessionId,
+                    'zone' => $zoneCode,
+                ]);
+                continue;
+            }
+
+            $summary['zones_processed']++;
+
+            foreach ($ruteros as $rutero) {
+                $summary['ruteros_seen']++;
+
+                $code = trim((string) ($rutero['code'] ?? ''));
+                if ($code === '') {
+                    $summary['ruteros_without_code']++;
+                    continue;
+                }
+
+                $zoneRows = Zone::query()->where('code', $code)->get();
+                if ($zoneRows->isEmpty()) {
+                    $summary['ruteros_unmatched']++;
+                    continue;
+                }
+
+                foreach ($zoneRows as $zoneRow) {
+                    $changes = [];
+                    foreach (['zone', 'route', 'day'] as $field) {
+                        $incoming = trim((string) ($rutero[$field] ?? ''));
+                        if ($incoming !== '' && $incoming !== trim((string) $zoneRow->{$field})) {
+                            $changes[$field] = $incoming;
+                        }
+                    }
+
+                    if ($changes !== []) {
+                        $zoneRow->update($changes);
+                        $summary['zone_rows_updated']++;
+
+                        Log::info('Zone rutero sync: client zone row updated', [
+                            'session_id' => $this->sessionId,
+                            'zone_row_id' => $zoneRow->id,
+                            'user_id' => $zoneRow->user_id,
+                            'code' => $code,
+                            'changes' => $changes,
+                        ]);
+                    }
+                }
+            }
+        }
+
+        Setting::updateOrCreate(
+            ['key' => 'last_zone_rutero_sync_at'],
+            ['name' => 'Última sincronización rutero por zona', 'value' => now()->toIso8601String(), 'show' => false]
+        );
+        Setting::updateOrCreate(
+            ['key' => 'last_zone_rutero_sync_session'],
+            ['name' => 'Sesión última sync rutero por zona', 'value' => $this->sessionId, 'show' => false]
+        );
+
+        Log::info('Zone rutero sync completed', array_merge(['session_id' => $this->sessionId], $summary));
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        Log::error('Zone rutero sync job failed', [
+            'session_id' => $this->sessionId,
+            'error' => $exception->getMessage(),
+        ]);
+    }
+}

--- a/app/Models/ClientDataUpdateRequest.php
+++ b/app/Models/ClientDataUpdateRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ClientDataUpdateRequest extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'zone_id',
+        'submitted_by',
+        'document',
+        'name',
+        'business_name',
+        'email',
+        'phone',
+        'mobile_phone',
+        'whatsapp',
+        'address',
+        'city_name',
+        'zone_code',
+        'route',
+        'day',
+        'seller_notes',
+        'previous_data',
+        'read_at',
+    ];
+
+    protected $casts = [
+        'previous_data' => 'array',
+        'read_at' => 'datetime',
+    ];
+
+    public function client(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function zone(): BelongsTo
+    {
+        return $this->belongsTo(Zone::class);
+    }
+
+    public function seller(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'submitted_by');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -66,6 +66,12 @@ class User extends Authenticatable
     const PENDING = 1;
     const ACTIVE = 2;
 
+    private const INTERNAL_EMAIL_SUFFIXES = [
+        '@tuti',
+        '@tuti.com',
+        '@tuti.com.co',
+    ];
+
     /**
      * The attributes that should be hidden for serialization.
      *
@@ -113,5 +119,35 @@ class User extends Authenticatable
     {
         return $this->belongsToMany(Product::class, 'user_favorite_products')
             ->withTimestamps();
+    }
+
+    public static function isInvalidClientEmail(?string $email): bool
+    {
+        if (!is_string($email) || trim($email) === '') {
+            return true;
+        }
+
+        $email = strtolower(trim($email));
+
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            return true;
+        }
+
+        foreach (self::INTERNAL_EMAIL_SUFFIXES as $suffix) {
+            if (str_ends_with($email, $suffix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function clientDisplayEmail(): ?string
+    {
+        if (self::isInvalidClientEmail($this->email)) {
+            return null;
+        }
+
+        return $this->email;
     }
 }

--- a/app/Models/Zone.php
+++ b/app/Models/Zone.php
@@ -90,6 +90,62 @@ class Zone extends Model
         return mb_strtolower(trim(preg_replace('/\s+/', ' ', $address) ?? $address), 'UTF-8');
     }
 
+    /**
+     * Resolve the Carbon dayOfWeek (0=domingo..6=sábado) encoded in a rutero `day`
+     * value. Depending on the source the field may be "5", "5-Viernes" or "Viernes".
+     */
+    public static function carbonDayOfWeekFromDay(?string $day): ?int
+    {
+        $raw = trim((string) $day);
+        if ($raw === '') {
+            return null;
+        }
+
+        $names = [
+            'domingo' => 0,
+            'lunes' => 1,
+            'martes' => 2,
+            'miercoles' => 3,
+            'miércoles' => 3,
+            'jueves' => 4,
+            'viernes' => 5,
+            'sabado' => 6,
+            'sábado' => 6,
+        ];
+
+        // Prefer the weekday name when present ("5-Viernes" or "Viernes").
+        $namePart = str_contains($raw, '-') ? trim(explode('-', $raw, 2)[1] ?? '') : $raw;
+        $nameKey = mb_strtolower($namePart, 'UTF-8');
+        if (isset($names[$nameKey])) {
+            return $names[$nameKey];
+        }
+
+        if (preg_match('/^\d+/', $raw, $matches)) {
+            $num = (int) $matches[0];
+            if ($num === 7) {
+                return 0; // 1=lunes..7=domingo convention
+            }
+            if ($num >= 0 && $num <= 6) {
+                return $num;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Spanish weekday label for a rutero `day` value, or null when unparsable.
+     */
+    public static function weekdayLabelFromDay(?string $day): ?string
+    {
+        $dow = self::carbonDayOfWeekFromDay($day);
+        if ($dow === null) {
+            return null;
+        }
+
+        return ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'][$dow] ?? null;
+    }
+
     public function usesCoordinadoraFor48h(): bool
     {
         return ($this->fulfillment_provider_48h ?? self::FULFILLMENT_PROVIDER_COORDINADORA) === self::FULFILLMENT_PROVIDER_COORDINADORA;

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -173,6 +173,27 @@ class UserRepository
     }
 
     /**
+     * Fetch every rutero registered in a zone (getRuteros with no document filter).
+     * Unlike getCustomRuteroId, this never retries without the zone: an empty result
+     * for a zone must stay empty instead of pulling the entire customer base.
+     *
+     * @return \Illuminate\Support\Collection<int, array<string, mixed>>|null Route rows (zone, route, day, code, ...) or null when the zone returned nothing.
+     */
+    public static function getRuterosForZone(string $zone): ?\Illuminate\Support\Collection
+    {
+        $token = Setting::where('key', 'microsoft_token')->first();
+
+        if ($token->updated_at->diffInMinutes(now()) > 25) {
+            Artisan::call('app:get-token');
+            $token = Setting::where('key', 'microsoft_token')->first();
+        }
+
+        $result = self::fetchRuteroData('', $zone, $token->value);
+
+        return $result ? collect($result['routes']) : null;
+    }
+
+    /**
      * Internal method to fetch rutero data from SOAP service
      * 
      * @param string $document

--- a/app/Repositories/UserRepository.php
+++ b/app/Repositories/UserRepository.php
@@ -143,16 +143,7 @@ class UserRepository
      */
     public static function getCustomRuteroId($document, $zone = null)
     {
-        $token = Setting::where('key', 'microsoft_token')->first();
-
-        //check if updated_at is grander than 30 minutes
-        if ($token->updated_at->diffInMinutes(now()) > 25) {
-            //call command app:get-token
-            Artisan::call('app:get-token');
-            $token = Setting::where('key', 'microsoft_token')->first();
-        }
-
-        $token = $token->value;
+        $token = self::freshMicrosoftToken();
         $originalZone = $zone;
         $zone = $zone ?? '';
 
@@ -181,6 +172,16 @@ class UserRepository
      */
     public static function getRuterosForZone(string $zone): ?\Illuminate\Support\Collection
     {
+        $result = self::fetchRuteroData('', $zone, self::freshMicrosoftToken());
+
+        return $result ? collect($result['routes']) : null;
+    }
+
+    /**
+     * Current Microsoft token value, refreshed via app:get-token when older than 25 minutes.
+     */
+    private static function freshMicrosoftToken(): string
+    {
         $token = Setting::where('key', 'microsoft_token')->first();
 
         if ($token->updated_at->diffInMinutes(now()) > 25) {
@@ -188,9 +189,7 @@ class UserRepository
             $token = Setting::where('key', 'microsoft_token')->first();
         }
 
-        $result = self::fetchRuteroData('', $zone, $token->value);
-
-        return $result ? collect($result['routes']) : null;
+        return $token->value;
     }
 
     /**

--- a/app/Rules/ValidClientEmail.php
+++ b/app/Rules/ValidClientEmail.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Rules;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class ValidClientEmail implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (!is_string($value) || trim($value) === '') {
+            return;
+        }
+
+        if (User::isInvalidClientEmail($value)) {
+            $fail('Debes ingresar un correo electrónico válido y personal (no se permiten correos @tuti).');
+        }
+    }
+}

--- a/app/Services/MailingService.php
+++ b/app/Services/MailingService.php
@@ -7,6 +7,7 @@ use App\Models\Order;
 use App\Models\User;
 use App\Models\Contact;
 use App\Models\CustomerServiceRequest;
+use App\Models\ClientDataUpdateRequest;
 use App\Models\Setting;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Log;
@@ -406,6 +407,45 @@ class MailingService
         } catch (\Throwable $e) {
             Log::error('Failed to send customer service PQRS email', [
                 'request_id' => $request->id ?? null,
+                'error' => $e->getMessage(),
+            ]);
+
+            return false;
+        }
+    }
+
+    /**
+     * Notify Tronex admin about a client data update request submitted by a seller.
+     */
+    public function sendClientDataUpdateNotification(ClientDataUpdateRequest $updateRequest): bool
+    {
+        try {
+            $this->updateMailConfiguration();
+
+            $recipient = 'administradorbdtat@tronex.com';
+            $subject = 'Actualización de datos de cliente - ' . ($updateRequest->business_name ?: $updateRequest->name ?: $updateRequest->document);
+
+            $updateRequest->loadMissing(['seller:id,name,email', 'client:id,name,document']);
+
+            $html = view('emails.client-data-update', [
+                'updateRequest' => $updateRequest,
+            ])->render();
+
+            Mail::html($html, function ($message) use ($recipient, $subject) {
+                $message->to($recipient)
+                    ->subject($subject)
+                    ->from(config('mail.from.address'), config('mail.from.name'));
+            });
+
+            Log::info('Client data update email sent', [
+                'request_id' => $updateRequest->id,
+                'recipient' => $recipient,
+            ]);
+
+            return true;
+        } catch (\Throwable $e) {
+            Log::error('Failed to send client data update email', [
+                'request_id' => $updateRequest->id ?? null,
                 'error' => $e->getMessage(),
             ]);
 

--- a/database/migrations/2026_06_16_000001_create_client_data_update_requests_table.php
+++ b/database/migrations/2026_06_16_000001_create_client_data_update_requests_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('client_data_update_requests', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('zone_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('submitted_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('document')->nullable();
+            $table->string('name')->nullable();
+            $table->string('business_name')->nullable();
+            $table->string('email')->nullable();
+            $table->string('phone')->nullable();
+            $table->string('mobile_phone')->nullable();
+            $table->string('whatsapp')->nullable();
+            $table->string('address')->nullable();
+            $table->string('city_name')->nullable();
+            $table->string('zone_code')->nullable();
+            $table->string('route')->nullable();
+            $table->string('day')->nullable();
+            $table->text('seller_notes')->nullable();
+            $table->json('previous_data')->nullable();
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('client_data_update_requests');
+    }
+};

--- a/resources/views/client-data-update-requests/index.blade.php
+++ b/resources/views/client-data-update-requests/index.blade.php
@@ -1,0 +1,70 @@
+@extends('layouts.admin')
+
+@section('content')
+<div class="p-4 bg-white border-b border-gray-200">
+    <div class="flex items-center justify-between mb-4">
+        <h1 class="text-xl font-semibold text-gray-900 sm:text-2xl">Actualización de datos</h1>
+    </div>
+
+    <form method="GET" action="{{ route('admin.client-data-update-requests.index') }}" class="flex flex-wrap items-end gap-4">
+        <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Buscar</label>
+            <input type="text" name="q" value="{{ request('q') }}" placeholder="Documento, nombre o razón social"
+                   class="border-gray-300 rounded-lg text-sm">
+        </div>
+        <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Desde</label>
+            <input type="date" name="date_from" value="{{ request('date_from') }}" class="border-gray-300 rounded-lg text-sm">
+        </div>
+        <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">Hasta</label>
+            <input type="date" name="date_to" value="{{ request('date_to') }}" class="border-gray-300 rounded-lg text-sm">
+        </div>
+        <button type="submit" class="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700">Filtrar</button>
+        <a href="{{ route('admin.client-data-update-requests.index') }}" class="px-4 py-2 bg-white border border-gray-300 text-gray-700 text-sm font-medium rounded-lg hover:bg-gray-50">Limpiar</a>
+    </form>
+</div>
+
+<div class="overflow-x-auto">
+    <table class="min-w-full divide-y divide-gray-200 bg-white">
+        <thead class="bg-gray-100">
+            <tr>
+                <th class="p-4 text-xs text-left font-medium text-gray-500 uppercase">Acciones</th>
+                <th class="p-4 text-xs text-left font-medium text-gray-500 uppercase">Fecha</th>
+                <th class="p-4 text-xs text-left font-medium text-gray-500 uppercase">Documento</th>
+                <th class="p-4 text-xs text-left font-medium text-gray-500 uppercase">Cliente</th>
+                <th class="p-4 text-xs text-left font-medium text-gray-500 uppercase">Vendedor</th>
+                <th class="p-4 text-xs text-left font-medium text-gray-500 uppercase">Estado</th>
+            </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-200">
+            @forelse($requests as $requestEntry)
+                <tr class="hover:bg-gray-50">
+                    <td class="p-4 text-sm">
+                        <a href="{{ route('admin.client-data-update-requests.show', $requestEntry) }}" class="text-blue-600 hover:text-blue-800 font-medium">Ver</a>
+                    </td>
+                    <td class="p-4 text-sm text-gray-700">{{ $requestEntry->created_at->format('d/m/Y H:i') }}</td>
+                    <td class="p-4 text-sm text-gray-900">{{ $requestEntry->document ?: '-' }}</td>
+                    <td class="p-4 text-sm text-gray-900">{{ $requestEntry->business_name ?: $requestEntry->name ?: ($requestEntry->client->name ?? '-') }}</td>
+                    <td class="p-4 text-sm text-gray-700">{{ $requestEntry->seller->name ?? '-' }}</td>
+                    <td class="p-4 text-sm">
+                        @if($requestEntry->read_at)
+                            <span class="inline-flex px-2 py-1 text-xs font-medium rounded-full bg-green-100 text-green-800">Leído</span>
+                        @else
+                            <span class="inline-flex px-2 py-1 text-xs font-medium rounded-full bg-amber-100 text-amber-800">Nuevo</span>
+                        @endif
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="6" class="p-6 text-center text-sm text-gray-500">No hay solicitudes de actualización de datos.</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+</div>
+
+<div class="mt-4">
+    {{ $requests->links() }}
+</div>
+@endsection

--- a/resources/views/client-data-update-requests/show.blade.php
+++ b/resources/views/client-data-update-requests/show.blade.php
@@ -1,0 +1,64 @@
+@extends('layouts.admin')
+
+@section('content')
+<div class="p-4">
+    <a href="{{ route('admin.client-data-update-requests.index') }}" class="inline-flex items-center text-sm text-gray-600 hover:text-gray-900 mb-4">
+        ← Volver a Actualización de datos
+    </a>
+
+    <div class="bg-white border border-gray-200 rounded-xl shadow-sm p-6 max-w-4xl">
+        <div class="flex items-center justify-between mb-6">
+            <h1 class="text-xl font-semibold text-gray-900">Solicitud #{{ $updateRequest->id }}</h1>
+            <span class="text-sm text-gray-500">{{ $updateRequest->created_at->format('d/m/Y H:i') }}</span>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm mb-6">
+            <div>
+                <p class="text-gray-500">Vendedor</p>
+                <p class="font-medium text-gray-900">{{ $updateRequest->seller->name ?? '-' }}</p>
+            </div>
+            <div>
+                <p class="text-gray-500">Estado</p>
+                <p class="font-medium text-gray-900">{{ $updateRequest->read_at ? 'Leído' : 'Nuevo' }}</p>
+            </div>
+        </div>
+
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">Datos solicitados</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+            <div><p class="text-gray-500">Cédula o NIT</p><p class="font-medium text-gray-900">{{ $updateRequest->document ?: '-' }}</p></div>
+            <div><p class="text-gray-500">Razón social</p><p class="font-medium text-gray-900">{{ $updateRequest->business_name ?: '-' }}</p></div>
+            <div><p class="text-gray-500">Nombre completo</p><p class="font-medium text-gray-900">{{ $updateRequest->name ?: '-' }}</p></div>
+            <div><p class="text-gray-500">Correo</p><p class="font-medium text-gray-900">{{ $updateRequest->email ?: '-' }}</p></div>
+            <div><p class="text-gray-500">Teléfono</p><p class="font-medium text-gray-900">{{ $updateRequest->phone ?: '-' }}</p></div>
+            <div><p class="text-gray-500">Celular</p><p class="font-medium text-gray-900">{{ $updateRequest->mobile_phone ?: '-' }}</p></div>
+            <div><p class="text-gray-500">WhatsApp</p><p class="font-medium text-gray-900">{{ $updateRequest->whatsapp ?: '-' }}</p></div>
+            <div><p class="text-gray-500">Ciudad</p><p class="font-medium text-gray-900">{{ $updateRequest->city_name ?: '-' }}</p></div>
+            <div class="md:col-span-2"><p class="text-gray-500">Dirección</p><p class="font-medium text-gray-900">{{ $updateRequest->address ?: '-' }}</p></div>
+            <div><p class="text-gray-500">Zona</p><p class="font-medium text-gray-900">{{ $updateRequest->zone_code ?: '-' }}</p></div>
+            <div><p class="text-gray-500">Ruta</p><p class="font-medium text-gray-900">{{ $updateRequest->route ?: '-' }}</p></div>
+            <div><p class="text-gray-500">Día de visita</p><p class="font-medium text-gray-900">{{ $updateRequest->day ?: '-' }}</p></div>
+        </div>
+
+        @if($updateRequest->seller_notes)
+            <div class="mt-6">
+                <p class="text-gray-500 text-sm">Notas del vendedor</p>
+                <div class="mt-1 p-4 rounded-lg bg-gray-50 border border-gray-200 text-sm text-gray-800 whitespace-pre-line">{{ $updateRequest->seller_notes }}</div>
+            </div>
+        @endif
+
+        @if(!empty($updateRequest->previous_data))
+            <div class="mt-6">
+                <h2 class="text-lg font-semibold text-gray-900 mb-3">Datos anteriores</h2>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
+                    @foreach($updateRequest->previous_data as $field => $value)
+                        <div>
+                            <p class="text-gray-500">{{ ucfirst(str_replace('_', ' ', $field)) }}</p>
+                            <p class="font-medium text-gray-900">{{ $value ?: '-' }}</p>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        @endif
+    </div>
+</div>
+@endsection

--- a/resources/views/client-data-updates/edit.blade.php
+++ b/resources/views/client-data-updates/edit.blade.php
@@ -1,0 +1,169 @@
+@extends('layouts.page')
+
+@section('head')
+@include('elements.seo', ['title' => ($isClientSelfService ?? false) ? 'Actualizar tus datos' : 'Actualizar datos del cliente'])
+@endsection
+
+@section('content')
+@php
+    $displayEmail = $client->clientDisplayEmail() ?? '';
+    $isClientSelfService = $isClientSelfService ?? false;
+    $defaultAddress = old('address', $ruteroRoute['address'] ?? $zone?->address ?? '');
+@endphp
+
+<section class="w-full max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div class="mb-6">
+        @if($isClientSelfService)
+            <a href="{{ route('logout') }}"
+               class="inline-flex items-center text-sm text-gray-600 hover:text-gray-900 mb-4">
+                Cerrar sesión
+            </a>
+        @else
+            <a href="{{ route('clients.orders.index', array_filter(['tab' => $returnTab, 'ruta' => $returnRoute ?: null])) }}"
+               class="inline-flex items-center text-sm text-gray-600 hover:text-gray-900 mb-4">
+                ← Volver a Mi Ruta
+            </a>
+        @endif
+
+        <h1 class="text-2xl sm:text-3xl font-semibold text-gray-900">
+            {{ $isClientSelfService ? 'Actualiza tus datos' : 'Actualizar datos del cliente' }}
+        </h1>
+
+        @if($isClientSelfService)
+            <div class="mt-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+                <p class="font-medium">Es necesario actualizar tus datos de contacto.</p>
+                <p class="mt-1">Tu cuenta tiene un correo temporal o inválido. Completa el formulario con tu información real para continuar con la activación.</p>
+            </div>
+        @else
+            <p class="text-sm text-gray-500 mt-1">Revisa y corrige la información del cliente. Los cambios quedarán registrados para revisión administrativa.</p>
+        @endif
+
+        @if($ruteroUnavailable ?? false)
+            <div class="mt-4 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+                No pudimos consultar la zona y la ruta en Tronex. Intenta más tarde o contáctanos por nuestros canales oficiales.
+            </div>
+        @endif
+
+        @if(session('success'))
+            <div class="mt-4 rounded-xl border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800">
+                {{ session('success') }}
+            </div>
+        @endif
+    </div>
+
+    <form method="POST"
+          action="{{ $isClientSelfService ? route('client-data-updates.client.store') : route('client-data-updates.store', $zone) }}"
+          class="space-y-6">
+        {{-- Seller flow always has a zone; client self-service may not. --}}
+        @csrf
+        @unless($isClientSelfService)
+            <input type="hidden" name="return_tab" value="{{ $returnTab }}">
+            <input type="hidden" name="return_route" value="{{ $returnRoute }}">
+        @endunless
+
+        <div class="bg-white border border-gray-200 rounded-2xl shadow-sm p-5 sm:p-6 space-y-4">
+            <h2 class="text-lg font-semibold text-gray-900">Información del cliente</h2>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                    <label for="document" class="block text-xs font-medium text-gray-500 mb-1">Cédula o NIT</label>
+                    <input type="text" name="document" id="document" value="{{ old('document', $client->document) }}" readonly
+                           class="w-full border-gray-200 rounded-lg text-sm bg-gray-50 px-3 py-2">
+                    @error('document') <p class="text-red-500 text-xs mt-1">{{ $message }}</p> @enderror
+                </div>
+                <div>
+                    <label for="business_name" class="block text-xs font-medium text-gray-500 mb-1">Razón social</label>
+                    <input type="text" name="business_name" id="business_name" value="{{ old('business_name', $client->business_name) }}"
+                           class="w-full border-gray-300 rounded-lg text-sm px-3 py-2 focus:ring-orange-500 focus:border-orange-500">
+                    @error('business_name') <p class="text-red-500 text-xs mt-1">{{ $message }}</p> @enderror
+                </div>
+                <div class="sm:col-span-2">
+                    <label for="name" class="block text-xs font-medium text-gray-500 mb-1">Nombre completo *</label>
+                    <input type="text" name="name" id="name" value="{{ old('name', $client->name) }}" required
+                           class="w-full border-gray-300 rounded-lg text-sm px-3 py-2 focus:ring-orange-500 focus:border-orange-500">
+                    @error('name') <p class="text-red-500 text-xs mt-1">{{ $message }}</p> @enderror
+                </div>
+                <div>
+                    <label for="email" class="block text-xs font-medium text-gray-500 mb-1">
+                        Correo electrónico{{ $isClientSelfService ? ' *' : '' }}
+                    </label>
+                    <input type="email" name="email" id="email" value="{{ old('email', $displayEmail) }}"
+                           @if($isClientSelfService) required @endif
+                           class="w-full border-gray-300 rounded-lg text-sm px-3 py-2 focus:ring-orange-500 focus:border-orange-500">
+                    @error('email') <p class="text-red-500 text-xs mt-1">{{ $message }}</p> @enderror
+                </div>
+                <div>
+                    <label for="phone" class="block text-xs font-medium text-gray-500 mb-1">Teléfono</label>
+                    <input type="text" name="phone" id="phone" value="{{ old('phone', $client->phone) }}"
+                           class="w-full border-gray-300 rounded-lg text-sm px-3 py-2 focus:ring-orange-500 focus:border-orange-500">
+                    @error('phone') <p class="text-red-500 text-xs mt-1">{{ $message }}</p> @enderror
+                </div>
+                <div>
+                    <label for="mobile_phone" class="block text-xs font-medium text-gray-500 mb-1">Celular</label>
+                    <input type="text" name="mobile_phone" id="mobile_phone" value="{{ old('mobile_phone', $client->mobile_phone) }}"
+                           class="w-full border-gray-300 rounded-lg text-sm px-3 py-2 focus:ring-orange-500 focus:border-orange-500">
+                    @error('mobile_phone') <p class="text-red-500 text-xs mt-1">{{ $message }}</p> @enderror
+                </div>
+                <div>
+                    <label for="whatsapp" class="block text-xs font-medium text-gray-500 mb-1">WhatsApp</label>
+                    <input type="text" name="whatsapp" id="whatsapp" value="{{ old('whatsapp', $client->whatsapp) }}"
+                           class="w-full border-gray-300 rounded-lg text-sm px-3 py-2 focus:ring-orange-500 focus:border-orange-500">
+                    @error('whatsapp') <p class="text-red-500 text-xs mt-1">{{ $message }}</p> @enderror
+                </div>
+            </div>
+        </div>
+
+        <div class="bg-white border border-gray-200 rounded-2xl shadow-sm p-5 sm:p-6 space-y-4">
+            <h2 class="text-lg font-semibold text-gray-900">Sucursal / ubicación</h2>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div class="sm:col-span-2">
+                    <label for="address" class="block text-xs font-medium text-gray-500 mb-1">Dirección *</label>
+                    <input type="text" name="address" id="address" value="{{ $defaultAddress }}" required
+                           class="w-full border-gray-300 rounded-lg text-sm px-3 py-2 focus:ring-orange-500 focus:border-orange-500">
+                    @error('address') <p class="text-red-500 text-xs mt-1">{{ $message }}</p> @enderror
+                </div>
+                <div>
+                    <label for="city_name" class="block text-xs font-medium text-gray-500 mb-1">Ciudad</label>
+                    <input type="text" name="city_name" id="city_name" value="{{ old('city_name', $client->city?->name) }}"
+                           class="w-full border-gray-300 rounded-lg text-sm px-3 py-2 focus:ring-orange-500 focus:border-orange-500">
+                    @error('city_name') <p class="text-red-500 text-xs mt-1">{{ $message }}</p> @enderror
+                </div>
+                <div>
+                    <span class="block text-xs font-medium text-gray-500 mb-1">Zona (Tronex)</span>
+                    <p class="text-sm text-gray-900 px-3 py-2 bg-gray-50 border border-gray-200 rounded-lg">{{ $ruteroRoute['zone_code'] ?? '—' }}</p>
+                </div>
+                <div>
+                    <span class="block text-xs font-medium text-gray-500 mb-1">Ruta (Tronex)</span>
+                    <p class="text-sm text-gray-900 px-3 py-2 bg-gray-50 border border-gray-200 rounded-lg">{{ $ruteroRoute['route'] ?? '—' }}</p>
+                </div>
+                <div>
+                    <span class="block text-xs font-medium text-gray-500 mb-1">Día de visita (Tronex)</span>
+                    <p class="text-sm text-gray-900 px-3 py-2 bg-gray-50 border border-gray-200 rounded-lg">{{ $ruteroRoute['day'] ?? '—' }}</p>
+                </div>
+            </div>
+            <p class="text-xs text-gray-500">Zona, ruta y día se consultan en Tronex y no pueden editarse manualmente.</p>
+        </div>
+
+        <div class="bg-white border border-gray-200 rounded-2xl shadow-sm p-5 sm:p-6">
+            <label for="seller_notes" class="block text-xs font-medium text-gray-500 mb-1">
+                {{ $isClientSelfService ? 'Comentarios adicionales (opcional)' : 'Notas adicionales (opcional)' }}
+            </label>
+            <textarea name="seller_notes" id="seller_notes" rows="4"
+                      class="w-full border-gray-300 rounded-lg text-sm px-3 py-2 focus:ring-orange-500 focus:border-orange-500"
+                      placeholder="{{ $isClientSelfService ? 'Indica cualquier detalle relevante para tu actualización.' : 'Indica cualquier detalle relevante para la actualización.' }}">{{ old('seller_notes') }}</textarea>
+            @error('seller_notes') <p class="text-red-500 text-xs mt-1">{{ $message }}</p> @enderror
+        </div>
+
+        <div class="flex items-center gap-3">
+            <button type="submit"
+                    @disabled($ruteroUnavailable ?? false)
+                    class="px-4 py-2 bg-orange-600 text-white text-sm font-medium rounded-lg hover:bg-orange-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+                Enviar actualización
+            </button>
+            @unless($isClientSelfService)
+                <a href="{{ route('clients.orders.index', array_filter(['tab' => $returnTab, 'ruta' => $returnRoute ?: null])) }}"
+                   class="text-sm text-gray-600 hover:text-gray-900">Cancelar</a>
+            @endunless
+        </div>
+    </form>
+</section>
+@endsection

--- a/resources/views/clients/orders/index.blade.php
+++ b/resources/views/clients/orders/index.blade.php
@@ -20,6 +20,12 @@
             <p class="text-sm text-gray-500 mt-1">Gestiona tu información personal y pedidos</p>
         </div>
 
+        @if(session('success'))
+            <div class="mb-6 p-4 bg-green-50 border border-green-200 rounded-xl text-sm text-green-800">
+                {{ session('success') }}
+            </div>
+        @endif
+
         {{-- ── Seller Mini Dashboard ─────────────────────────── --}}
         @if(!empty($isSeller))
         <div id="seller-dashboard" class="mb-8">

--- a/resources/views/clients/orders/index.blade.php
+++ b/resources/views/clients/orders/index.blade.php
@@ -78,6 +78,15 @@
                         Pedidos del dia
                     </div>
                 </button>
+                <button type="button" data-tab-trigger="mi-ruta"
+                        class="flex-1 px-4 py-4 text-sm font-semibold text-gray-700 hover:bg-gray-50 border-b border-gray-200">
+                    <div class="flex items-center justify-center gap-2">
+                        <svg class="w-5 h-5 text-orange-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7" />
+                        </svg>
+                        Mi Ruta
+                    </div>
+                </button>
                 @endif
                 <button type="button" data-tab-trigger="orders"
                         class="flex-1 px-4 py-4 text-sm font-semibold text-gray-700 hover:bg-gray-50 border-b border-gray-200">
@@ -130,6 +139,10 @@
                     ],
                     'emptyMessage' => 'No tienes pedidos para el rango seleccionado.',
                 ])
+            </div>
+
+            <div data-tab-panel="mi-ruta" class="hidden">
+                @include('clients.orders.partials.my-route-panel', ['myRoute' => $myRoute])
             </div>
             @endif
 

--- a/resources/views/clients/orders/partials/my-route-panel.blade.php
+++ b/resources/views/clients/orders/partials/my-route-panel.blade.php
@@ -1,0 +1,90 @@
+@php
+    $myRoute = $myRoute ?? [];
+    $sellerZone = $myRoute['sellerZone'] ?? '';
+    $routeOptions = $myRoute['routeOptions'] ?? collect();
+    $selectedRoute = $myRoute['selectedRoute'] ?? '';
+    $routeClients = $myRoute['clients'] ?? null;
+    $todayLabel = $myRoute['todayLabel'] ?? '';
+@endphp
+
+<div class="space-y-6">
+    @if($sellerZone === '')
+        <div class="bg-white border border-gray-200 rounded-2xl shadow-sm p-6 text-center text-gray-500">
+            No tienes una zona asignada. Contacta al administrador para configurar tu zona.
+        </div>
+    @elseif($routeOptions->isEmpty())
+        <div class="bg-white border border-gray-200 rounded-2xl shadow-sm p-6 text-center text-gray-500">
+            No encontramos rutas para tu zona {{ $sellerZone }}.
+        </div>
+    @else
+        <div class="bg-white border border-gray-200 rounded-2xl shadow-sm p-4 sm:p-6">
+            <form method="GET" action="{{ route('clients.orders.index') }}">
+                <input type="hidden" name="tab" value="mi-ruta">
+                <div class="flex flex-col sm:flex-row sm:items-end gap-3">
+                    <div class="flex-1 min-w-0">
+                        <label for="mi-ruta-select" class="block text-xs font-medium text-gray-500 mb-1">Ruta (zona {{ $sellerZone }})</label>
+                        <select id="mi-ruta-select" name="ruta" data-orders-autosubmit
+                                class="w-full border-gray-300 rounded-lg text-sm px-3 py-2 focus:ring-orange-500 focus:border-orange-500">
+                            <option value="">Selecciona una ruta</option>
+                            @foreach($routeOptions as $routeOption)
+                                <option value="{{ $routeOption }}" @selected((string) $routeOption === $selectedRoute)>{{ $routeOption }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <p class="text-sm text-gray-500 sm:pb-2 whitespace-nowrap">
+                        Hoy: <span class="font-medium text-gray-700 capitalize">{{ $todayLabel }}</span>
+                    </p>
+                </div>
+            </form>
+        </div>
+
+        @if($selectedRoute === '')
+            <div class="bg-white border border-gray-200 rounded-2xl shadow-sm p-6 text-center text-gray-500">
+                Selecciona una ruta para ver los clientes con visita programada para hoy.
+            </div>
+        @elseif($routeClients === null || $routeClients->isEmpty())
+            <div class="bg-white border border-gray-200 rounded-2xl shadow-sm p-6 text-center text-gray-500">
+                No hay clientes en la ruta {{ $selectedRoute }} con visita programada para hoy.
+            </div>
+        @else
+            <div class="bg-white border border-gray-200 rounded-2xl shadow-sm overflow-hidden">
+                <div class="px-4 sm:px-6 py-4 border-b border-gray-100 flex items-center justify-between">
+                    <h2 class="text-sm font-semibold text-gray-900">Clientes de la ruta {{ $selectedRoute }}</h2>
+                    <span class="text-xs font-medium text-gray-500">{{ $routeClients->count() }} {{ $routeClients->count() === 1 ? 'cliente' : 'clientes' }}</span>
+                </div>
+                <ul class="divide-y divide-gray-100">
+                    @foreach($routeClients as $clientZone)
+                        @php $client = $clientZone->user; @endphp
+                        <li class="p-4 sm:px-6 flex flex-col sm:flex-row sm:items-center gap-3">
+                            <div class="flex-1 min-w-0">
+                                <p class="text-sm font-semibold text-gray-900">{{ $client->name }}</p>
+                                @if($client->business_name)
+                                    <p class="text-xs text-gray-500">{{ $client->business_name }}</p>
+                                @endif
+                                <p class="text-xs text-gray-500 mt-1">
+                                    Documento: {{ $client->document ?? '-' }} · Tel: {{ $client->mobile_phone ?? $client->phone ?? '-' }}
+                                </p>
+                                <p class="text-xs text-gray-500">{{ $clientZone->address ?? '-' }}</p>
+                            </div>
+                            <div class="flex items-center gap-3">
+                                <span class="text-xs font-medium text-orange-600 bg-orange-50 rounded-full px-2.5 py-1">
+                                    {{ \App\Models\Zone::weekdayLabelFromDay($clientZone->day) ?? $clientZone->day }}
+                                </span>
+                                @if($client->document)
+                                    <form method="POST" action="{{ route('seller.setclient') }}">
+                                        @csrf
+                                        <input type="hidden" name="document" value="{{ $client->document }}">
+                                        <button type="submit"
+                                                class="px-3 py-2 bg-orange-600 text-white text-xs font-medium rounded-lg hover:bg-orange-700 transition-colors">
+                                            Crear pedido
+                                        </button>
+                                    </form>
+                                @endif
+                            </div>
+                        </li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
+    @endif
+</div>

--- a/resources/views/clients/orders/partials/my-route-panel.blade.php
+++ b/resources/views/clients/orders/partials/my-route-panel.blade.php
@@ -47,43 +47,85 @@
                 No hay clientes en la ruta {{ $selectedRoute }} con visita programada para hoy.
             </div>
         @else
-            <div class="bg-white border border-gray-200 rounded-2xl shadow-sm overflow-hidden">
-                <div class="px-4 sm:px-6 py-4 border-b border-gray-100 flex items-center justify-between">
+            <div class="space-y-4">
+                <div class="flex items-center justify-between px-1">
                     <h2 class="text-sm font-semibold text-gray-900">Clientes de la ruta {{ $selectedRoute }}</h2>
                     <span class="text-xs font-medium text-gray-500">{{ $routeClients->count() }} {{ $routeClients->count() === 1 ? 'cliente' : 'clientes' }}</span>
                 </div>
-                <ul class="divide-y divide-gray-100">
-                    @foreach($routeClients as $clientZone)
-                        @php $client = $clientZone->user; @endphp
-                        <li class="p-4 sm:px-6 flex flex-col sm:flex-row sm:items-center gap-3">
-                            <div class="flex-1 min-w-0">
-                                <p class="text-sm font-semibold text-gray-900">{{ $client->name }}</p>
-                                @if($client->business_name)
-                                    <p class="text-xs text-gray-500">{{ $client->business_name }}</p>
-                                @endif
-                                <p class="text-xs text-gray-500 mt-1">
-                                    Documento: {{ $client->document ?? '-' }} · Tel: {{ $client->mobile_phone ?? $client->phone ?? '-' }}
-                                </p>
-                                <p class="text-xs text-gray-500">{{ $clientZone->address ?? '-' }}</p>
-                            </div>
-                            <div class="flex items-center gap-3">
-                                <span class="text-xs font-medium text-orange-600 bg-orange-50 rounded-full px-2.5 py-1">
-                                    {{ \App\Models\Zone::weekdayLabelFromDay($clientZone->day) ?? $clientZone->day }}
-                                </span>
-                                @if($client->document)
-                                    <form method="POST" action="{{ route('seller.setclient') }}">
-                                        @csrf
-                                        <input type="hidden" name="document" value="{{ $client->document }}">
-                                        <button type="submit"
-                                                class="px-3 py-2 bg-orange-600 text-white text-xs font-medium rounded-lg hover:bg-orange-700 transition-colors">
-                                            Crear pedido
-                                        </button>
-                                    </form>
+
+                @foreach($routeClients as $clientZone)
+                    @php
+                        $client = $clientZone->user;
+                        $displayEmail = $client->email;
+                        if (is_string($displayEmail) && str_ends_with(strtolower($displayEmail), '@tuti.com')) {
+                            $displayEmail = null;
+                        }
+                        $fullAddress = collect([$clientZone->address, $client->city?->name])
+                            ->filter(fn ($part) => filled($part))
+                            ->implode(', ');
+                    @endphp
+                    <div class="bg-white border border-gray-200 rounded-2xl shadow-sm p-4 sm:p-6">
+                        <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+                            <div class="min-w-0">
+                                <p class="text-sm font-semibold text-gray-900">{{ $client->business_name ?: $client->name }}</p>
+                                @if($client->business_name && $client->business_name !== $client->name)
+                                    <p class="text-xs text-gray-500 mt-0.5">{{ $client->name }}</p>
                                 @endif
                             </div>
-                        </li>
-                    @endforeach
-                </ul>
+                            <span class="self-start text-xs font-medium text-orange-600 bg-orange-50 rounded-full px-2.5 py-1 whitespace-nowrap">
+                                {{ \App\Models\Zone::weekdayLabelFromDay($clientZone->day) ?? $clientZone->day }}
+                            </span>
+                        </div>
+
+                        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4 text-sm">
+                            <div>
+                                <p class="text-xs text-gray-500 uppercase">Cédula o NIT</p>
+                                <p class="font-semibold text-gray-800 break-words">{{ $client->document ?: '-' }}</p>
+                            </div>
+                            <div>
+                                <p class="text-xs text-gray-500 uppercase">Razón social</p>
+                                <p class="font-semibold text-gray-800 break-words">{{ $client->business_name ?: $client->name ?: '-' }}</p>
+                            </div>
+                            <div class="sm:col-span-2">
+                                <p class="text-xs text-gray-500 uppercase">Dirección</p>
+                                <p class="font-semibold text-gray-800 break-words">{{ $fullAddress ?: '-' }}</p>
+                            </div>
+                            <div>
+                                <p class="text-xs text-gray-500 uppercase">Teléfono</p>
+                                <p class="font-semibold text-gray-800 break-words">{{ $client->phone ?: '-' }}</p>
+                            </div>
+                            <div>
+                                <p class="text-xs text-gray-500 uppercase">Celular</p>
+                                <p class="font-semibold text-gray-800 break-words">{{ $client->mobile_phone ?: '-' }}</p>
+                            </div>
+                            <div>
+                                <p class="text-xs text-gray-500 uppercase">WhatsApp</p>
+                                <p class="font-semibold text-gray-800 break-words">{{ $client->whatsapp ?: '-' }}</p>
+                            </div>
+                            <div>
+                                <p class="text-xs text-gray-500 uppercase">Correo</p>
+                                <p class="font-semibold text-gray-800 break-words">{{ $displayEmail ?: '-' }}</p>
+                            </div>
+                        </div>
+
+                        @if($client->document)
+                            <div class="mt-4 pt-4 border-t border-gray-100 flex flex-col sm:flex-row sm:justify-end gap-2">
+                                <a href="{{ route('client-data-updates.edit', ['zone' => $clientZone->id, 'return_tab' => 'mi-ruta', 'ruta' => $selectedRoute]) }}"
+                                   class="px-3 py-2 border border-gray-300 text-gray-700 text-xs font-medium rounded-lg hover:bg-gray-50 transition-colors text-center">
+                                    Actualizar datos
+                                </a>
+                                <form method="POST" action="{{ route('seller.setclient') }}">
+                                    @csrf
+                                    <input type="hidden" name="document" value="{{ $client->document }}">
+                                    <button type="submit"
+                                            class="w-full sm:w-auto px-3 py-2 bg-orange-600 text-white text-xs font-medium rounded-lg hover:bg-orange-700 transition-colors">
+                                        Crear pedido
+                                    </button>
+                                </form>
+                            </div>
+                        @endif
+                    </div>
+                @endforeach
             </div>
         @endif
     @endif

--- a/resources/views/elements/admin/aside.blade.php
+++ b/resources/views/elements/admin/aside.blade.php
@@ -141,6 +141,12 @@
                                 <span class="ml-3">PQRS</span>
                             </a>
                         </li>
+                        <li>
+                            <a href="{{ route('admin.client-data-update-requests.index') }}">
+                                @svg('heroicon-o-pencil-square', 'w-6 h-6 text-gray-500')
+                                <span class="ml-3">Actualización de datos</span>
+                            </a>
+                        </li>
 
 
                 

--- a/resources/views/emails/client-data-update.blade.php
+++ b/resources/views/emails/client-data-update.blade.php
@@ -1,0 +1,42 @@
+<html>
+<body style="font-family: Arial, sans-serif; color: #111827;">
+    <h2 style="margin-bottom: 12px;">Actualización de datos de cliente</h2>
+
+    <p><strong>ID solicitud:</strong> #{{ $updateRequest->id }}</p>
+    <p><strong>Fecha:</strong> {{ $updateRequest->created_at?->format('d/m/Y H:i') }}</p>
+    @if($updateRequest->seller)
+        <p><strong>Vendedor:</strong> {{ $updateRequest->seller->name }} ({{ $updateRequest->seller->email }})</p>
+    @endif
+
+    <h3 style="margin: 20px 0 8px;">Datos solicitados</h3>
+    <p><strong>Cédula o NIT:</strong> {{ $updateRequest->document ?: '-' }}</p>
+    <p><strong>Razón social / nombre:</strong> {{ $updateRequest->name ?: '-' }}</p>
+    <p><strong>Nombre del negocio:</strong> {{ $updateRequest->business_name ?: '-' }}</p>
+    <p><strong>Correo:</strong> {{ $updateRequest->email ?: '-' }}</p>
+    <p><strong>Teléfono:</strong> {{ $updateRequest->phone ?: '-' }}</p>
+    <p><strong>Celular:</strong> {{ $updateRequest->mobile_phone ?: '-' }}</p>
+    <p><strong>WhatsApp:</strong> {{ $updateRequest->whatsapp ?: '-' }}</p>
+    <p><strong>Dirección:</strong> {{ $updateRequest->address ?: '-' }}</p>
+    <p><strong>Ciudad:</strong> {{ $updateRequest->city_name ?: '-' }}</p>
+    <p><strong>Zona:</strong> {{ $updateRequest->zone_code ?: '-' }}</p>
+    <p><strong>Ruta:</strong> {{ $updateRequest->route ?: '-' }}</p>
+    <p><strong>Día de visita:</strong> {{ $updateRequest->day ?: '-' }}</p>
+
+    @if($updateRequest->seller_notes)
+        <p><strong>Notas del vendedor:</strong></p>
+        <p style="white-space: pre-line;">{{ $updateRequest->seller_notes }}</p>
+    @endif
+
+    @if(!empty($updateRequest->previous_data))
+        <h3 style="margin: 20px 0 8px;">Datos anteriores registrados</h3>
+        @foreach($updateRequest->previous_data as $field => $value)
+            <p><strong>{{ ucfirst(str_replace('_', ' ', $field)) }}:</strong> {{ $value ?: '-' }}</p>
+        @endforeach
+    @endif
+
+    <hr style="margin: 16px 0;">
+    <p style="font-size: 12px; color: #6B7280;">
+        Enviado desde TUTI — solicitud de actualización de datos de cliente.
+    </p>
+</body>
+</html>

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -28,6 +28,7 @@ use App\Http\Controllers\Admin\ContactController;
 use App\Http\Controllers\Admin\SellerController;
 use App\Http\Controllers\Admin\CustomerServiceContactController;
 use App\Http\Controllers\Admin\CustomerServiceRequestController;
+use App\Http\Controllers\Admin\ClientDataUpdateRequestController;
 use App\Http\Controllers\Admin\FeaturedProductController;
 use App\Http\Controllers\Admin\FeaturedCategoryController;
 use App\Http\Controllers\Admin\ShippingMethodController;
@@ -42,9 +43,11 @@ use App\Http\Controllers\Admin\DocumentationController;
 use Illuminate\Support\Facades\Route;
 
 
-Route::middleware(['auth', 'role:seller'])->group(function () {
+Route::middleware(['auth', 'role:seller|supervisor'])->group(function () {
     Route::post('/setclient', [SellerController::class, 'setclient'])->name('seller.setclient');
     Route::post('/removeclient', [SellerController::class, 'removeclient'])->name('seller.removeclient');
+    Route::get('/actualizacion-datos/{zone}/editar', [\App\Http\Controllers\ClientDataUpdateController::class, 'edit'])->name('client-data-updates.edit');
+    Route::post('/actualizacion-datos/{zone}', [\App\Http\Controllers\ClientDataUpdateController::class, 'store'])->name('client-data-updates.store');
 });
 
 Route::middleware(['auth', 'role:admin'])->group(function () {
@@ -330,6 +333,8 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::resource('contacts', ContactController::class);
     Route::get('customer-service-requests', [CustomerServiceRequestController::class, 'index'])->name('admin.customer-service-requests.index');
     Route::get('customer-service-requests/{customerServiceRequest}', [CustomerServiceRequestController::class, 'show'])->name('admin.customer-service-requests.show');
+    Route::get('client-data-update-requests', [ClientDataUpdateRequestController::class, 'index'])->name('admin.client-data-update-requests.index');
+    Route::get('client-data-update-requests/{clientDataUpdateRequest}', [ClientDataUpdateRequestController::class, 'show'])->name('admin.client-data-update-requests.show');
     Route::get('email-templates', [App\Http\Controllers\Admin\EmailTemplateController::class, 'index'])->name('admin.email-templates.index');
     Route::get('email-templates/create', [App\Http\Controllers\Admin\EmailTemplateController::class, 'create'])->name('admin.email-templates.create');
     Route::post('email-templates', [App\Http\Controllers\Admin\EmailTemplateController::class, 'store'])->name('admin.email-templates.store');

--- a/tests/Feature/ClientDataUpdateTest.php
+++ b/tests/Feature/ClientDataUpdateTest.php
@@ -1,0 +1,193 @@
+<?php
+
+use App\Models\ClientDataUpdateRequest;
+use App\Models\User;
+use App\Models\Zone;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+
+use function Pest\Laravel\actingAs;
+
+uses(RefreshDatabase::class);
+
+function mockRuteroForDataUpdate(array $routeOverrides = []): void
+{
+    $route = array_merge([
+        'zone' => '301',
+        'route' => 'R100',
+        'day' => '1',
+        'address' => 'Calle 10 # 20-30',
+        'code' => 'RUT-1',
+    ], $routeOverrides);
+
+    \Mockery::mock('alias:App\Repositories\UserRepository')
+        ->shouldReceive('getCustomRuteroId')
+        ->andReturn([
+            'name' => 'Cliente Tronex',
+            'routes' => [$route],
+        ]);
+}
+
+afterEach(function () {
+    \Mockery::close();
+});
+
+it('allows a seller to submit a client data update request', function () {
+    mockRuteroForDataUpdate();
+
+    Role::firstOrCreate(['name' => 'seller', 'guard_name' => 'web']);
+
+    $seller = User::factory()->create(['zone' => '301']);
+    $seller->assignRole('seller');
+
+    $client = User::factory()->create([
+        'name' => 'Cliente Original',
+        'document' => '901234567',
+        'business_name' => 'Tienda Original',
+        'phone' => '6011111111',
+        'mobile_phone' => '3001111111',
+        'whatsapp' => '3001111111',
+        'email' => 'cliente@example.com',
+    ]);
+
+    $zone = Zone::create([
+        'user_id' => $client->id,
+        'zone' => '301',
+        'route' => 'R100',
+        'day' => '1',
+        'address' => 'Calle 10 # 20-30',
+        'code' => 'RUT-1',
+    ]);
+
+    actingAs($seller)
+        ->post(route('client-data-updates.store', $zone), [
+            'document' => '901234567',
+            'name' => 'Cliente Actualizado',
+            'business_name' => 'Tienda Actualizada',
+            'email' => 'nuevo@example.com',
+            'phone' => '6022222222',
+            'mobile_phone' => '3002222222',
+            'whatsapp' => '3003333333',
+            'address' => 'Calle 20 # 30-40',
+            'city_name' => 'Bogotá',
+            'seller_notes' => 'Corrección de teléfonos',
+            'return_tab' => 'mi-ruta',
+            'return_route' => 'R100',
+        ])
+        ->assertRedirect(route('clients.orders.index', ['tab' => 'mi-ruta', 'ruta' => 'R100']));
+
+    $request = ClientDataUpdateRequest::first();
+
+    expect($request)->not->toBeNull()
+        ->and($request->name)->toBe('Cliente Actualizado')
+        ->and($request->business_name)->toBe('Tienda Actualizada')
+        ->and($request->zone_code)->toBe('301')
+        ->and($request->route)->toBe('R100')
+        ->and($request->day)->toBe('1')
+        ->and($request->submitted_by)->toBe($seller->id)
+        ->and($request->previous_data['name'])->toBe('Cliente Original')
+        ->and(ClientDataUpdateRequest::count())->toBe(1);
+});
+
+it('stores zone and route from getRutero even if the request tries to override them', function () {
+    mockRuteroForDataUpdate(['zone' => '301', 'route' => 'R100']);
+
+    Role::firstOrCreate(['name' => 'seller', 'guard_name' => 'web']);
+
+    $seller = User::factory()->create(['zone' => '301']);
+    $seller->assignRole('seller');
+
+    $client = User::factory()->create([
+        'document' => '901234567',
+        'email' => 'cliente@example.com',
+    ]);
+
+    $zone = Zone::create([
+        'user_id' => $client->id,
+        'zone' => '301',
+        'route' => 'R100',
+        'day' => '1',
+        'address' => 'Calle 10',
+        'code' => 'RUT-1',
+    ]);
+
+    actingAs($seller)
+        ->post(route('client-data-updates.store', $zone), [
+            'document' => '901234567',
+            'name' => 'Cliente Actualizado',
+            'address' => 'Calle 20',
+            'zone_code' => '999',
+            'route' => 'R999',
+            'day' => '9',
+            'return_tab' => 'mi-ruta',
+        ])
+        ->assertRedirect();
+
+    $request = ClientDataUpdateRequest::first();
+
+    expect($request->zone_code)->toBe('301')
+        ->and($request->route)->toBe('R100')
+        ->and($request->day)->toBe('1');
+});
+
+it('shows the seller edit form prefilled with client data and rutero zone route', function () {
+    mockRuteroForDataUpdate();
+
+    Role::firstOrCreate(['name' => 'seller', 'guard_name' => 'web']);
+
+    $seller = User::factory()->create(['zone' => '301']);
+    $seller->assignRole('seller');
+
+    $client = User::factory()->create([
+        'name' => 'Cliente Formulario',
+        'document' => '123456789',
+        'business_name' => 'Negocio Formulario',
+        'mobile_phone' => '3009999999',
+    ]);
+
+    $zone = Zone::create([
+        'user_id' => $client->id,
+        'zone' => '301',
+        'route' => 'R100',
+        'day' => '1',
+        'address' => 'Calle 1',
+        'code' => 'RUT-FORM',
+    ]);
+
+    actingAs($seller)
+        ->get(route('client-data-updates.edit', ['zone' => $zone->id, 'return_tab' => 'mi-ruta', 'ruta' => 'R100']))
+        ->assertOk()
+        ->assertSee('Actualizar datos del cliente')
+        ->assertSee('123456789')
+        ->assertSee('Negocio Formulario')
+        ->assertSee('3009999999')
+        ->assertSee('Zona (Tronex)')
+        ->assertSee('R100')
+        ->assertDontSee('name="zone_code"', false);
+});
+
+it('lists client data update requests in admin', function () {
+    Role::firstOrCreate(['name' => 'admin', 'guard_name' => 'web']);
+
+    $admin = User::factory()->create();
+    $admin->assignRole('admin');
+
+    $client = User::factory()->create(['document' => '555666777']);
+    $seller = User::factory()->create(['name' => 'Vendedor Uno']);
+
+    ClientDataUpdateRequest::create([
+        'user_id' => $client->id,
+        'submitted_by' => $seller->id,
+        'document' => '555666777',
+        'name' => 'Cliente Admin',
+        'business_name' => 'Tienda Admin',
+        'address' => 'Calle 99',
+    ]);
+
+    actingAs($admin)
+        ->get(route('admin.client-data-update-requests.index'))
+        ->assertOk()
+        ->assertSee('Actualización de datos')
+        ->assertSee('555666777')
+        ->assertSee('Tienda Admin');
+});

--- a/tests/Feature/SellerMyRouteTabTest.php
+++ b/tests/Feature/SellerMyRouteTabTest.php
@@ -30,7 +30,15 @@ it('shows only route clients whose visit day matches today in mi ruta tab', func
     $todayDow = Carbon::now('America/Bogota')->dayOfWeek;
     $otherDow = ($todayDow + 1) % 7;
 
-    $clientToday = User::factory()->create(['name' => 'Cliente Visita Hoy', 'document' => '111222333']);
+    $clientToday = User::factory()->create([
+        'name' => 'Cliente Visita Hoy',
+        'document' => '901234567',
+        'business_name' => 'Tienda El Progreso',
+        'phone' => '6012345678',
+        'mobile_phone' => '3001234567',
+        'whatsapp' => '3007654321',
+        'email' => 'tienda@example.com',
+    ]);
     Zone::create([
         'user_id' => $clientToday->id,
         'zone' => '301',
@@ -65,6 +73,13 @@ it('shows only route clients whose visit day matches today in mi ruta tab', func
     $response->assertOk()
         ->assertSee('Mi Ruta')
         ->assertSee('Cliente Visita Hoy')
+        ->assertSee('Tienda El Progreso')
+        ->assertSee('901234567')
+        ->assertSee('6012345678')
+        ->assertSee('3001234567')
+        ->assertSee('3007654321')
+        ->assertSee('tienda@example.com')
+        ->assertSee('Calle 1 # 2-3')
         ->assertDontSee('Cliente Otro Dia')
         ->assertDontSee('Cliente Otra Ruta');
 });

--- a/tests/Feature/SellerMyRouteTabTest.php
+++ b/tests/Feature/SellerMyRouteTabTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use App\Models\User;
+use App\Models\Zone;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+
+use function Pest\Laravel\actingAs;
+
+uses(RefreshDatabase::class);
+
+it('parses rutero day values into carbon day of week', function () {
+    expect(Zone::carbonDayOfWeekFromDay('5'))->toBe(5)
+        ->and(Zone::carbonDayOfWeekFromDay('5-Viernes'))->toBe(5)
+        ->and(Zone::carbonDayOfWeekFromDay('3-Miércoles'))->toBe(3)
+        ->and(Zone::carbonDayOfWeekFromDay('miercoles'))->toBe(3)
+        ->and(Zone::carbonDayOfWeekFromDay('Sábado'))->toBe(6)
+        ->and(Zone::carbonDayOfWeekFromDay('7'))->toBe(0)
+        ->and(Zone::carbonDayOfWeekFromDay(''))->toBeNull()
+        ->and(Zone::carbonDayOfWeekFromDay(null))->toBeNull();
+});
+
+it('shows only route clients whose visit day matches today in mi ruta tab', function () {
+    Role::firstOrCreate(['name' => 'seller', 'guard_name' => 'web']);
+
+    $seller = User::factory()->create(['zone' => '301']);
+    $seller->assignRole('seller');
+
+    $todayDow = Carbon::now('America/Bogota')->dayOfWeek;
+    $otherDow = ($todayDow + 1) % 7;
+
+    $clientToday = User::factory()->create(['name' => 'Cliente Visita Hoy', 'document' => '111222333']);
+    Zone::create([
+        'user_id' => $clientToday->id,
+        'zone' => '301',
+        'route' => 'R100',
+        'day' => (string) $todayDow,
+        'address' => 'Calle 1 # 2-3',
+        'code' => 'RUT-HOY',
+    ]);
+
+    $clientOtherDay = User::factory()->create(['name' => 'Cliente Otro Dia', 'document' => '444555666']);
+    Zone::create([
+        'user_id' => $clientOtherDay->id,
+        'zone' => '301',
+        'route' => 'R100',
+        'day' => (string) $otherDow,
+        'address' => 'Calle 4 # 5-6',
+        'code' => 'RUT-OTRO-DIA',
+    ]);
+
+    $clientOtherRoute = User::factory()->create(['name' => 'Cliente Otra Ruta', 'document' => '777888999']);
+    Zone::create([
+        'user_id' => $clientOtherRoute->id,
+        'zone' => '301',
+        'route' => 'R200',
+        'day' => (string) $todayDow,
+        'address' => 'Calle 7 # 8-9',
+        'code' => 'RUT-OTRA-RUTA',
+    ]);
+
+    $response = actingAs($seller)->get('/ordenes?tab=mi-ruta&ruta=R100');
+
+    $response->assertOk()
+        ->assertSee('Mi Ruta')
+        ->assertSee('Cliente Visita Hoy')
+        ->assertDontSee('Cliente Otro Dia')
+        ->assertDontSee('Cliente Otra Ruta');
+});
+
+it('lists the routes available for the seller zone', function () {
+    Role::firstOrCreate(['name' => 'seller', 'guard_name' => 'web']);
+
+    $seller = User::factory()->create(['zone' => '301']);
+    $seller->assignRole('seller');
+
+    $client = User::factory()->create(['document' => '123123123']);
+    Zone::create([
+        'user_id' => $client->id,
+        'zone' => '301',
+        'route' => 'R100',
+        'day' => '1',
+        'address' => 'Calle 1',
+        'code' => 'RUT-1',
+    ]);
+    Zone::create([
+        'user_id' => $client->id,
+        'zone' => '999',
+        'route' => 'R900',
+        'day' => '1',
+        'address' => 'Calle 9',
+        'code' => 'RUT-9',
+    ]);
+
+    $response = actingAs($seller)->get('/ordenes?tab=mi-ruta');
+
+    $response->assertOk()
+        ->assertSee('R100')
+        ->assertDontSee('R900');
+});


### PR DESCRIPTION
## Summary
- Adds the seller **Mi Ruta** tab: route picker, today's visit clients (Colombia timezone), and **Crear pedido** action.
- Adds weekly `clients:sync-zone-ruteros` job to refresh client zona/ruta/día from Dynamics getRuteros.
- Adds **Actualizar datos** flow from Mi Ruta (seller form → admin review → email notification).

## Scope notes
This PR cherry-picks only the Mi Ruta slice from `stage`. It intentionally excludes other stage work (pending clients, forced password change, Pedidos del día changes, etc.).

## Test plan
- [ ] Run migration: `php artisan migrate`
- [ ] Log in as seller with zone assigned → `/ordenes?tab=mi-ruta`
- [ ] Select a route and confirm only today's clients appear
- [ ] Click **Crear pedido** and confirm client is set for checkout
- [ ] Click **Actualizar datos**, submit a change, confirm admin sees it under **Actualización de datos**
- [ ] Verify `php artisan test tests/Feature/SellerMyRouteTabTest.php tests/Feature/ClientDataUpdateTest.php`


Made with [Cursor](https://cursor.com)